### PR TITLE
Fix Android stability and release automation

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -5,7 +5,12 @@ on:
     paths:
       - android/**
       - ci/endpoint_parity.py
+      - ci/generate_android_localization_catalog.py
+      - ci/migrate_android_compose_literals.py
+      - ci/android_localization_aliases.json
+      - ci/android_supplemental_localizations.json
       - HermesMobile/Networking/Endpoints.swift
+      - HermesMobile/Resources/Localizable.xcstrings
       - .github/workflows/android-ci.yml
   push:
     branches:
@@ -13,7 +18,12 @@ on:
     paths:
       - android/**
       - ci/endpoint_parity.py
+      - ci/generate_android_localization_catalog.py
+      - ci/migrate_android_compose_literals.py
+      - ci/android_localization_aliases.json
+      - ci/android_supplemental_localizations.json
       - HermesMobile/Networking/Endpoints.swift
+      - HermesMobile/Resources/Localizable.xcstrings
       - .github/workflows/android-ci.yml
 
 permissions:

--- a/.github/workflows/android-named-release.yml
+++ b/.github/workflows/android-named-release.yml
@@ -28,7 +28,10 @@ jobs:
   android-artifacts:
     name: Android Artifacts
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
+    outputs:
+      version_name: ${{ steps.release_identity.outputs.version_name }}
+      version_code: ${{ steps.release_identity.outputs.version_code }}
     steps:
       - name: Check out
         uses: actions/checkout@v7
@@ -42,8 +45,39 @@ jobs:
       - name: Gradle cache
         uses: gradle/actions/setup-gradle@v5
 
+      - name: Enable emulator acceleration
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Validate release identity
+        id: release_identity
+        run: |
+          set -euo pipefail
+          version_name="$(sed -n 's/^[[:space:]]*versionName = "\([^"]*\)"/\1/p' android/app/build.gradle.kts)"
+          version_code="$(sed -n 's/^[[:space:]]*versionCode = \([0-9][0-9]*\)/\1/p' android/app/build.gradle.kts)"
+          expected_tag="android-v${version_name}"
+          if [ -z "$version_name" ] || [ -z "$version_code" ]; then
+            echo "Could not read Android version identity"
+            exit 1
+          fi
+          if [ "${{ inputs.tag_name }}" != "$expected_tag" ]; then
+            echo "Tag must be $expected_tag for versionName $version_name"
+            exit 1
+          fi
+          echo "ANDROID_VERSION_NAME=$version_name" >> "$GITHUB_ENV"
+          echo "ANDROID_VERSION_CODE=$version_code" >> "$GITHUB_ENV"
+          echo "version_name=$version_name" >> "$GITHUB_OUTPUT"
+          echo "version_code=$version_code" >> "$GITHUB_OUTPUT"
+
       - name: Verify endpoint parity
         run: python3 ci/endpoint_parity.py
+
+      - name: Verify localization catalog parity
+        run: |
+          python3 ci/generate_android_localization_catalog.py --check
+          python3 ci/migrate_android_compose_literals.py --check
 
       - name: Prepare Android release signing
         env:
@@ -72,7 +106,7 @@ jobs:
 
       - name: Test and build Android artifacts
         working-directory: android
-        run: ./gradlew testDebugUnitTest lintRelease assembleRelease bundleRelease
+        run: ./gradlew testDebugUnitTest lintRelease pixel2api35DebugAndroidTest assembleRelease bundleRelease
 
       - name: Upload Android artifacts
         uses: actions/upload-artifact@v5
@@ -96,27 +130,25 @@ jobs:
           path: dist
 
       - name: Create release notes
+        env:
+          ANDROID_VERSION_NAME: ${{ needs.android-artifacts.outputs.version_name }}
+          ANDROID_VERSION_CODE: ${{ needs.android-artifacts.outputs.version_code }}
         run: |
-          cat > release-notes.md <<'EOF'
-          Hermex 1.0.4 native Android release artifacts.
+          cat > release-notes.md <<EOF
+          Hermex ${ANDROID_VERSION_NAME} native Android release artifacts (version code ${ANDROID_VERSION_CODE}).
 
           The APK and AAB are signed with the permanent Hermex release key. Keep using
           this signing identity for every future update.
 
-          Changes in 1.0.4:
-          - Prevents voice-note, shared-draft, and Git mutation data loss.
-          - Hardens authentication redirects, HTTP error handling, link previews, media, and share intents.
-          - Migrates active secret storage to Android Keystore AES-GCM with automatic legacy migration.
-          - Loads independent server configuration requests concurrently for faster screens.
-          - Improves pagination, deep-link, shortcut, localization, and managed-device reliability.
-
-          Upgrade note: 1.0.4 installs directly over production-signed 1.0.x builds.
+          Upgrade note: ${ANDROID_VERSION_NAME} installs directly over production-signed 1.0.x builds.
           GitHub APKs from 0.2.7 and earlier used a debug signature and may still require
           uninstalling the old app once before installing this release.
 
           This release was gated by:
           - iOS/Android endpoint parity
+          - Android localization catalog parity
           - Android unit tests
+          - Android API 35 managed-device tests
           - Android release lint
           - production-signed release APK and AAB builds
           EOF

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@
 
 Your server. Your phone. No middleman.
 
-[![Release 1.0.4](https://img.shields.io/badge/release-1.0.4-2F6B4F)](https://github.com/Hungbocluaqua/hermex-android-port/releases/tag/android-v1.0.4)
+[![Latest release](https://img.shields.io/github/v/release/Hungbocluaqua/hermex-android-port?label=release&color=2F6B4F)](https://github.com/Hungbocluaqua/hermex-android-port/releases/latest)
 [![Android 8+](https://img.shields.io/badge/Android-8%2B-3DDC84?logo=android&logoColor=white)](android/README.md)
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.3-7F52FF?logo=kotlin&logoColor=white)](https://kotlinlang.org)
 [![Jetpack Compose](https://img.shields.io/badge/Jetpack-Compose-4285F4?logo=jetpackcompose&logoColor=white)](https://developer.android.com/compose)
 [![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg)](LICENSE)
 
-[![Download APK](https://img.shields.io/badge/Download-signed%20APK-2F6B4F?style=for-the-badge&logo=android&logoColor=white)](https://github.com/Hungbocluaqua/hermex-android-port/releases/download/android-v1.0.4/app-release.apk)
+[![Download APK](https://img.shields.io/badge/Download-signed%20APK-2F6B4F?style=for-the-badge&logo=android&logoColor=white)](https://github.com/Hungbocluaqua/hermex-android-port/releases/latest/download/app-release.apk)
 
 [Latest release](https://github.com/Hungbocluaqua/hermex-android-port/releases/latest) · [Android source](android/) · [Report a bug](https://github.com/Hungbocluaqua/hermex-android-port/issues) · [Contributing](CONTRIBUTING.md)
 
@@ -29,22 +29,16 @@ Hermex is a native Kotlin and Jetpack Compose port of the original SwiftUI app. 
 
 The original iPhone app is still maintained in this repository, but this README focuses on the Android port and its releases.
 
-## Install Hermex 1.0.4
+## Install Hermex
 
 Hermex is currently distributed as a signed APK through GitHub Releases and requires Android 8.0 (API 26) or newer.
 
-1. Download [`app-release.apk`](https://github.com/Hungbocluaqua/hermex-android-port/releases/download/android-v1.0.4/app-release.apk) on your Android device.
+1. Download the latest signed [`app-release.apk`](https://github.com/Hungbocluaqua/hermex-android-port/releases/latest/download/app-release.apk) on your Android device.
 2. If prompted, allow your browser or file manager to install apps from that source.
 3. Open the APK and install Hermex. Future signed releases can be installed over the existing app.
 4. Enter your `hermes-webui` server URL and password during onboarding.
 
-The matching AAB is included on the [1.0.4 release page](https://github.com/Hungbocluaqua/hermex-android-port/releases/tag/android-v1.0.4) for store distribution; Android users should install the APK instead.
-
-APK SHA-256:
-
-```text
-367d0ccca4d8eb7f0f0791d5ffc14076565a53b81d0a2629682bd15a098492c9
-```
+The matching AAB and version-specific notes are available on the [latest release page](https://github.com/Hungbocluaqua/hermex-android-port/releases/latest) for store distribution and release verification; Android users should install the APK instead.
 
 ## Android features
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         applicationId = "com.uzairansar.hermex"
         minSdk = 26
         targetSdk = 36
-        versionCode = 14
-        versionName = "1.0.4"
+        versionCode = 15
+        versionName = "1.0.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/android/app/src/androidTest/java/com/uzairansar/hermex/HermexUiFlowTest.kt
+++ b/android/app/src/androidTest/java/com/uzairansar/hermex/HermexUiFlowTest.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.test.down
 import androidx.compose.ui.test.moveBy
 import androidx.compose.ui.test.swipeLeft
 import androidx.compose.ui.test.swipeDown
+import androidx.compose.ui.test.swipeUp
 import androidx.compose.ui.test.up
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performSemanticsAction
@@ -814,6 +815,12 @@ class HermexUiFlowTest {
                                     event: done
                                     data: {"session_id":"s1"}
 
+                                    event: title
+                                    data: {"session_id":"s1","title":"Post-done title"}
+
+                                    event: stream_end
+                                    data: {}
+
                                     """.trimIndent(),
                                 )
                             }
@@ -881,6 +888,20 @@ class HermexUiFlowTest {
         composeRule.waitUntil(timeoutMillis = 5_000) { hasText("Mobile") }
         composeRule.onNodeWithText("GPT-5").performClick()
         composeRule.waitUntil(timeoutMillis = 5_000) { hasText("Choose Model") }
+        val pickerBeforeScroll = composeRule
+            .onNodeWithTag("picker_sheet", useUnmergedTree = true)
+            .fetchSemanticsNode()
+            .boundsInRoot
+        composeRule.onNodeWithTag("model_picker_list").performTouchInput { swipeUp() }
+        composeRule.waitForIdle()
+        Thread.sleep(250)
+        composeRule.waitForIdle()
+        val pickerAfterScroll = composeRule
+            .onNodeWithTag("picker_sheet", useUnmergedTree = true)
+            .fetchSemanticsNode()
+            .boundsInRoot
+        assertTrue(abs(pickerAfterScroll.top - pickerBeforeScroll.top) <= 1f)
+        assertTrue(abs(pickerAfterScroll.bottom - pickerBeforeScroll.bottom) <= 1f)
         composeRule.onNodeWithText("Search models").performTextInput("gpt-4o")
         composeRule.onNodeWithTag("model_picker_list").performScrollToNode(hasSemanticsText("GPT-4o"))
         composeRule.onNodeWithText("GPT-4o").performClick()
@@ -925,6 +946,7 @@ class HermexUiFlowTest {
         composeRule.onNodeWithContentDescription("Message").performTextInput("Hello Android")
         composeRule.onNodeWithContentDescription("Send").performClick()
         composeRule.waitUntil(timeoutMillis = 5_000) { hasText("Mock response") }
+        composeRule.waitUntil(timeoutMillis = 5_000) { hasText("Post-done title") }
 
         composeRule.onNodeWithText("Mock response").assertExists()
         val topBarBounds = composeRule.onNodeWithTag("chat_top_bar").fetchSemanticsNode().boundsInRoot
@@ -1445,7 +1467,7 @@ class HermexUiFlowTest {
 
     @Test
     fun panelsRouteGroupsAndSearchesSkillsLikeIos() {
-        val longSkillContent = (1..24).joinToString("\\n\\n") { section ->
+        val longSkillContent = (1..1_600).joinToString("\\n\\n") { section ->
             "Section $section: detailed skill guidance for scrolling stability."
         }
         val mockServer = MockWebServer().also { server ->
@@ -1558,6 +1580,7 @@ class HermexUiFlowTest {
 
     @Test
     fun panelsRouteShowsTaskMetadataLikeIos() {
+        val longTaskOutput = (1..80).joinToString("\\n") { line -> "Output line $line" }
         val mockServer = MockWebServer().also { server ->
             server.dispatcher = object : Dispatcher() {
                 override fun dispatch(request: RecordedRequest): MockResponse {
@@ -1575,9 +1598,10 @@ class HermexUiFlowTest {
                                   "running": true,
                                   "next_run_at": "2026-07-06T09:00:00Z",
                                   "last_run_at": "2026-07-05T09:00:00Z",
-                                  "deliver": "local",
-                                  "model": "gpt-5",
-                                  "profile": "review",
+                                   "deliver": "local",
+                                   "model": "gpt-5",
+                                   "provider": "openai-codex",
+                                   "profile": "review",
                                   "skills": ["code-review", "summary"]
                                 }
                               ]
@@ -1585,6 +1609,9 @@ class HermexUiFlowTest {
                             """.trimIndent(),
                         )
                         "/api/crons/status" -> json("""{"running_jobs":{}}""")
+                        "/api/crons/output" -> json(
+                            """{"job_id":"job-1","outputs":[{"filename":"latest.md","content":"$longTaskOutput"}]}""",
+                        )
                         "/api/skills" -> json("""{"skills":[]}""")
                         "/api/insights" -> json("""{"period_days":30,"total_sessions":0,"total_messages":0,"total_tokens":0}""")
                         else -> MockResponse.Builder().code(404).body("""{"error":"unexpected"}""").build()
@@ -1624,6 +1651,28 @@ class HermexUiFlowTest {
         composeRule.onNodeWithText("review").assertIsDisplayed()
         composeRule.onNodeWithText("Skills").assertIsDisplayed()
         composeRule.onNodeWithText("code-review, summary").assertIsDisplayed()
+        composeRule.onNodeWithText("Morning Review").performClick()
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithTag("task_detail_scroll", useUnmergedTree = true).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule
+            .onNodeWithTag("task_detail_scroll", useUnmergedTree = true)
+            .performScrollToNode(hasSemanticsText("openai-codex"))
+        composeRule.onNodeWithText("openai-codex").assertIsDisplayed()
+        val taskSheetBeforeScroll = composeRule
+            .onNodeWithTag("task_detail_sheet", useUnmergedTree = true)
+            .fetchSemanticsNode()
+            .boundsInRoot
+        composeRule.onNodeWithTag("task_detail_scroll", useUnmergedTree = true).performTouchInput { swipeUp() }
+        composeRule.waitForIdle()
+        Thread.sleep(250)
+        composeRule.waitForIdle()
+        val taskSheetAfterScroll = composeRule
+            .onNodeWithTag("task_detail_sheet", useUnmergedTree = true)
+            .fetchSemanticsNode()
+            .boundsInRoot
+        assertTrue(abs(taskSheetAfterScroll.top - taskSheetBeforeScroll.top) <= 1f)
+        assertTrue(abs(taskSheetAfterScroll.bottom - taskSheetBeforeScroll.bottom) <= 1f)
     }
 
     @Test

--- a/android/app/src/androidTest/java/com/uzairansar/hermex/data/secure/AndroidSecretStoreTest.kt
+++ b/android/app/src/androidTest/java/com/uzairansar/hermex/data/secure/AndroidSecretStoreTest.kt
@@ -11,6 +11,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -77,5 +78,6 @@ class AndroidSecretStoreTest {
 
         assertEquals("legacy-secret", store.getString("servers"))
         assertEquals("legacy-secret", AndroidSecretStore(context).getString("servers"))
+        assertTrue(context.getSharedPreferences("hermex_secure", Context.MODE_PRIVATE).all.isEmpty())
     }
 }

--- a/android/app/src/main/java/com/uzairansar/hermex/core/model/Dto.kt
+++ b/android/app/src/main/java/com/uzairansar/hermex/core/model/Dto.kt
@@ -1334,6 +1334,7 @@ data class ProfileSwitchResponse(
     val profiles: List<ProfileSummary>? = null,
     val active: String? = null,
     @SerialName("default_model") val defaultModel: String? = null,
+    @SerialName("default_model_provider") val defaultModelProvider: String? = null,
     @SerialName("default_workspace") val defaultWorkspace: String? = null,
     val error: String? = null,
 )
@@ -1362,6 +1363,8 @@ data class SettingsResponse(
     @SerialName("bot_name") val botName: String? = null,
     val theme: String? = null,
     @SerialName("show_cli_sessions") val showCliSessions: Boolean? = null,
+    @SerialName("default_model") val defaultModel: String? = null,
+    @SerialName("default_model_provider") val defaultModelProvider: String? = null,
 )
 
 @Serializable
@@ -1403,6 +1406,7 @@ data class UpdatesApplyResponse(
 data class DefaultModelResponse(
     val ok: Boolean? = null,
     val model: String? = null,
+    val provider: String? = null,
     val error: String? = null,
 )
 
@@ -1434,6 +1438,7 @@ data class CronJob(
     val deliver: String? = null,
     val skills: List<String>? = null,
     val model: String? = null,
+    val provider: String? = null,
     val profile: String? = null,
     @SerialName("toast_notifications") val toastNotifications: Boolean? = null,
 )

--- a/android/app/src/main/java/com/uzairansar/hermex/core/model/MutationConfirmation.kt
+++ b/android/app/src/main/java/com/uzairansar/hermex/core/model/MutationConfirmation.kt
@@ -1,0 +1,60 @@
+package com.uzairansar.hermex.core.model
+
+fun SessionMutationResponse.isConfirmedMutation(): Boolean =
+    error.isNullOrBlank() && ok != false && (ok == true || session != null)
+
+fun SessionClearResponse.isConfirmedMutation(): Boolean =
+    error.isNullOrBlank() && ok != false && (ok == true || session != null)
+
+fun SessionCompressResponse.isConfirmedMutation(): Boolean =
+    error.isNullOrBlank() && ok != false && (ok == true || session != null)
+
+fun SessionUndoResponse.isConfirmedMutation(): Boolean =
+    error.isNullOrBlank() && ok == true
+
+fun SessionRetryResponse.isConfirmedMutation(): Boolean =
+    error.isNullOrBlank() && ok == true
+
+fun ProjectMutationResponse.isConfirmedMutation(): Boolean =
+    error.isNullOrBlank() && ok != false && (ok == true || project != null)
+
+fun CronMutationResponse.isConfirmedMutation(): Boolean =
+    error.isNullOrBlank() && ok != false && (ok == true || job != null || !jobId.isNullOrBlank())
+
+fun ChatCancelResponse.isConfirmedMutation(): Boolean =
+    error.isNullOrBlank() && ok == true
+
+fun GoalSubmissionResponse.isConfirmedMutation(): Boolean =
+    error.isNullOrBlank() && ok == true && !action.equals("error", ignoreCase = true)
+
+fun PersonalitySetResponse.isConfirmedPersonalityMutation(requestedName: String): Boolean =
+    error.isNullOrBlank() &&
+        ok == true &&
+        if (requestedName.isBlank()) personality.isNullOrBlank() else personality == requestedName
+
+fun ApprovalRespondResponse.isConfirmedMutation(): Boolean =
+    ok == true || staleCleared == true || staleClearedSnake == true
+
+fun SessionYoloResponse.isConfirmedYoloMutation(enabled: Boolean): Boolean =
+    error.isNullOrBlank() && ok == true && isEnabled == enabled
+
+fun ClarificationRespondResponse.isConfirmedClarification(responseText: String): Boolean =
+    ok == true && (response == null || response == responseText)
+
+fun DefaultModelResponse.isConfirmedDefaultModel(providerId: String?): Boolean =
+    error.isNullOrBlank() &&
+        ok == true &&
+        !model.isNullOrBlank() &&
+        (providerId.isNullOrBlank() || provider.equals(providerId, ignoreCase = true))
+
+fun ProfileSwitchResponse.isConfirmedProfileSwitch(profileName: String): Boolean =
+    error.isNullOrBlank() && active.equals(profileName, ignoreCase = true)
+
+fun ProfileCreateResponse.isConfirmedMutation(): Boolean =
+    error.isNullOrBlank() && ok == true
+
+fun MemoryWriteResponse.isConfirmedMutation(): Boolean =
+    error.isNullOrBlank() && ok == true
+
+fun SettingsResponse.isConfirmedShowCliSessions(enabled: Boolean): Boolean =
+    showCliSessions == enabled

--- a/android/app/src/main/java/com/uzairansar/hermex/core/model/Requests.kt
+++ b/android/app/src/main/java/com/uzairansar/hermex/core/model/Requests.kt
@@ -156,6 +156,7 @@ data class ClarifyRespondRequest(
 @Serializable
 data class DefaultModelRequest(
     val model: String,
+    val provider: String? = null,
 )
 
 @Serializable
@@ -191,6 +192,7 @@ data class CronCreateRequest(
     val deliver: String? = null,
     val skills: List<String> = emptyList(),
     val model: String? = null,
+    val provider: String? = null,
     val profile: String? = null,
     @SerialName("toast_notifications") val toastNotifications: Boolean,
 )
@@ -204,6 +206,7 @@ data class CronUpdateRequest(
     val deliver: String? = null,
     val skills: List<String>? = null,
     val model: String? = null,
+    val provider: String? = null,
     val profile: String? = null,
     @SerialName("toast_notifications") val toastNotifications: Boolean? = null,
 )

--- a/android/app/src/main/java/com/uzairansar/hermex/core/network/HermesApiClient.kt
+++ b/android/app/src/main/java/com/uzairansar/hermex/core/network/HermesApiClient.kt
@@ -237,7 +237,8 @@ class HermesApiClient(
     suspend fun personalities(): PersonalitiesResponse = get(Endpoint.Personalities)
     suspend fun setPersonality(sessionId: String, name: String): PersonalitySetResponse =
         post(Endpoint.SetPersonality, SetPersonalityRequest(sessionId, name))
-    suspend fun defaultModel(model: String): DefaultModelResponse = post(Endpoint.DefaultModel, DefaultModelRequest(model))
+    suspend fun defaultModel(model: String, provider: String? = null): DefaultModelResponse =
+        post(Endpoint.DefaultModel, DefaultModelRequest(model, provider))
     suspend fun insights(days: Int): InsightsResponse = get(Endpoint.Insights(days))
     suspend fun crons(): CronsResponse = get(Endpoint.Crons)
     suspend fun createCron(request: CronCreateRequest): CronMutationResponse = post(Endpoint.CronCreate, request)

--- a/android/app/src/main/java/com/uzairansar/hermex/core/network/PersistentCookieJar.kt
+++ b/android/app/src/main/java/com/uzairansar/hermex/core/network/PersistentCookieJar.kt
@@ -36,11 +36,7 @@ class PersistentCookieJar(
 
     fun clear(url: HttpUrl) {
         synchronized(lock) {
-            val host = url.host.lowercase()
-            persist(readAll(url).filterNot { record ->
-                val domain = record.domain.lowercase().trimStart('.')
-                host == domain || host.endsWith(".$domain") || domain.endsWith(".$host")
-            })
+            persist(readAll(url).filterNot { record -> record.toCookie()?.matches(url) == true })
             secretStore.remove(legacyKeyFor(url))
         }
     }

--- a/android/app/src/main/java/com/uzairansar/hermex/core/network/SseEvent.kt
+++ b/android/app/src/main/java/com/uzairansar/hermex/core/network/SseEvent.kt
@@ -29,8 +29,19 @@ sealed interface SseEvent {
     data class ApprovalPending(val response: ApprovalPendingResponse) : SseEvent
     data class ClarificationPending(val response: ClarificationPendingResponse) : SseEvent
     data object StreamEnd : SseEvent
-    data object Cancelled : SseEvent
-    data class Error(val message: String) : SseEvent
+    data class Cancelled(
+        val session: SessionDetail? = null,
+        val sessionId: String? = null,
+        val replacementSessionId: String? = null,
+    ) : SseEvent
+    data class Error(
+        val message: String,
+        val session: SessionDetail? = null,
+        val sessionId: String? = null,
+        val replacementSessionId: String? = null,
+        val hint: String? = null,
+        val details: String? = null,
+    ) : SseEvent
     data class TransportError(val message: String) : SseEvent
     data object Ignored : SseEvent
 }
@@ -75,9 +86,15 @@ private data class DonePayload(
 )
 
 @Serializable
-private data class ErrorPayload(
+private data class TerminalPayload(
     val error: String? = null,
     val message: String? = null,
+    val session: SessionDetail? = null,
+    @SerialName("session_id") val sessionId: String? = null,
+    @SerialName("new_session_id") val newSessionId: String? = null,
+    @SerialName("continuation_session_id") val continuationSessionId: String? = null,
+    val hint: String? = null,
+    val details: String? = null,
 )
 
 object SseEventDecoder {
@@ -103,9 +120,22 @@ object SseEventDecoder {
                 }
                 "pending_steer_leftover" -> SseEvent.PendingSteerLeftover(HermesJson.decodeFromString<TextPayload>(data).text.orEmpty())
                 "stream_end" -> SseEvent.StreamEnd
-                "cancel" -> SseEvent.Cancelled
-                "error", "apperror" -> HermesJson.decodeFromString<ErrorPayload>(data).let {
-                    SseEvent.Error(it.error ?: it.message ?: "The stream returned an error.")
+                "cancel" -> HermesJson.decodeFromString<TerminalPayload>(data).let {
+                    SseEvent.Cancelled(
+                        session = it.session,
+                        sessionId = it.sessionId ?: it.session?.sessionId,
+                        replacementSessionId = it.continuationSessionId ?: it.newSessionId,
+                    )
+                }
+                "error", "apperror" -> HermesJson.decodeFromString<TerminalPayload>(data).let {
+                    SseEvent.Error(
+                        message = it.error ?: it.message ?: "The stream returned an error.",
+                        session = it.session,
+                        sessionId = it.sessionId ?: it.session?.sessionId,
+                        replacementSessionId = it.continuationSessionId ?: it.newSessionId,
+                        hint = it.hint,
+                        details = it.details,
+                    )
                 }
                 "approval" -> SseEvent.ApprovalPending(HermesJson.decodeFromString(data))
                 "clarify" -> SseEvent.ClarificationPending(HermesJson.decodeFromString(data))

--- a/android/app/src/main/java/com/uzairansar/hermex/data/repository/ChatRepository.kt
+++ b/android/app/src/main/java/com/uzairansar/hermex/data/repository/ChatRepository.kt
@@ -33,6 +33,7 @@ import com.uzairansar.hermex.core.model.WorkspacesResponse
 import com.uzairansar.hermex.core.model.compressionAnchorMetadata
 import com.uzairansar.hermex.core.model.contextWindowSnapshot
 import com.uzairansar.hermex.core.model.hasOlderMessages
+import com.uzairansar.hermex.core.model.isConfirmedMutation
 import com.uzairansar.hermex.core.model.resolvedMessagesOffset
 import com.uzairansar.hermex.core.network.HermesApiClient
 import com.uzairansar.hermex.core.network.ApiError
@@ -198,7 +199,7 @@ class ChatRepository(
     suspend fun compressSession(sessionId: String, focusTopic: String?) = run {
         val operationGeneration = cacheOwnership.generation(serverUrl)
         client.compressSession(sessionId, focusTopic).also { response ->
-            if (response.ok != false && response.error.isNullOrBlank()) {
+            if (response.isConfirmedMutation()) {
                 response.session?.let { session ->
                     val resolvedSessionId = session.sessionId?.takeIf { it.isNotBlank() } ?: sessionId
                     replaceCachedMessages(resolvedSessionId, session.messages.orEmpty(), generation = operationGeneration)
@@ -211,7 +212,7 @@ class ChatRepository(
     suspend fun renameSession(sessionId: String, title: String): SessionMutationResponse {
         val operationGeneration = cacheOwnership.generation(serverUrl)
         val response = client.renameSession(sessionId, title)
-        if (response.ok != false && response.error.isNullOrBlank()) {
+        if (response.isConfirmedMutation()) {
             cacheOwnership.writeIfCurrent(serverUrl, operationGeneration) {
                 cacheDao.updateSessionTitle(serverUrl, sessionId, title)
             }
@@ -244,7 +245,7 @@ class ChatRepository(
     suspend fun clearSessionSnapshot(sessionId: String): ChatSessionClearResult {
         val response = client.clearSession(sessionId)
         val error = response.error?.trim()?.takeIf { it.isNotBlank() }
-        if (response.ok == false || error != null) {
+        if (!response.isConfirmedMutation()) {
             return ChatSessionClearResult(error = error ?: "The server could not clear this conversation.")
         }
 

--- a/android/app/src/main/java/com/uzairansar/hermex/data/repository/PanelsRepository.kt
+++ b/android/app/src/main/java/com/uzairansar/hermex/data/repository/PanelsRepository.kt
@@ -33,7 +33,7 @@ class PanelsRepository(private val client: HermesApiClient) {
     suspend fun applyUpdate(target: String = "webui"): UpdatesApplyResponse = client.applyUpdate(target)
     suspend fun models(): ModelCatalogResponse = client.models()
     suspend fun modelsLive(): ModelsLiveResponse = client.modelsLive()
-    suspend fun saveDefaultModel(model: String): DefaultModelResponse = client.defaultModel(model)
+    suspend fun saveDefaultModel(model: String, provider: String? = null): DefaultModelResponse = client.defaultModel(model, provider)
     suspend fun profiles(): ProfilesResponse = client.profiles()
     suspend fun switchProfile(profile: String): ProfileSwitchResponse = client.switchProfile(profile)
     suspend fun createProfile(

--- a/android/app/src/main/java/com/uzairansar/hermex/data/repository/SessionRepository.kt
+++ b/android/app/src/main/java/com/uzairansar/hermex/data/repository/SessionRepository.kt
@@ -11,6 +11,7 @@ import com.uzairansar.hermex.core.model.SessionExportFormat
 import com.uzairansar.hermex.core.model.SessionMutationResponse
 import com.uzairansar.hermex.core.model.SessionSummary
 import com.uzairansar.hermex.core.model.SessionUsageResponse
+import com.uzairansar.hermex.core.model.isConfirmedMutation
 import com.uzairansar.hermex.core.network.HermesApiClient
 import com.uzairansar.hermex.core.network.ApiError
 import com.uzairansar.hermex.data.db.CacheDao
@@ -82,7 +83,7 @@ class SessionRepository(
     suspend fun rename(sessionId: String, title: String): SessionMutationResponse {
         val cacheGeneration = cacheOwnership.generation(serverUrl)
         val response = client.renameSession(sessionId, title)
-        if (response.isSuccessfulMutation()) {
+        if (response.isConfirmedMutation()) {
             cacheOwnership.writeIfCurrent(serverUrl, cacheGeneration) {
                 cacheDao.updateSessionTitle(serverUrl, sessionId, title)
             }
@@ -92,7 +93,7 @@ class SessionRepository(
 
     suspend fun clear(sessionId: String): SessionClearResponse {
         val response = client.clearSession(sessionId)
-        if (response.ok != false && response.error.isNullOrBlank()) {
+        if (response.isConfirmedMutation()) {
             cacheOwnership.invalidateAndClear(serverUrl) {
                 cacheDao.deleteCachedSessionMessages(serverUrl, sessionId)
             }
@@ -102,7 +103,7 @@ class SessionRepository(
 
     suspend fun delete(sessionId: String): SessionMutationResponse {
         val response = client.deleteSession(sessionId)
-        if (response.isSuccessfulMutation()) {
+        if (response.isConfirmedMutation()) {
             cacheOwnership.invalidateAndClear(serverUrl) {
                 cacheDao.purgeSession(serverUrl, sessionId)
             }
@@ -113,7 +114,7 @@ class SessionRepository(
     suspend fun pin(sessionId: String, pinned: Boolean): SessionMutationResponse {
         val cacheGeneration = cacheOwnership.generation(serverUrl)
         val response = client.pinSession(sessionId, pinned)
-        if (response.isSuccessfulMutation()) {
+        if (response.isConfirmedMutation()) {
             cacheOwnership.writeIfCurrent(serverUrl, cacheGeneration) {
                 cacheDao.updateSessionPinned(serverUrl, sessionId, pinned)
             }
@@ -124,7 +125,7 @@ class SessionRepository(
     suspend fun archive(sessionId: String, archived: Boolean): SessionMutationResponse {
         val cacheGeneration = cacheOwnership.generation(serverUrl)
         val response = client.archiveSession(sessionId, archived)
-        if (response.isSuccessfulMutation()) {
+        if (response.isConfirmedMutation()) {
             cacheOwnership.writeIfCurrent(serverUrl, cacheGeneration) {
                 cacheDao.updateSessionArchived(serverUrl, sessionId, archived)
             }
@@ -135,7 +136,7 @@ class SessionRepository(
     suspend fun move(sessionId: String, projectId: String?): SessionMutationResponse {
         val cacheGeneration = cacheOwnership.generation(serverUrl)
         val response = client.moveSession(sessionId, projectId)
-        if (response.isSuccessfulMutation()) {
+        if (response.isConfirmedMutation()) {
             cacheOwnership.writeIfCurrent(serverUrl, cacheGeneration) {
                 cacheDao.updateSessionProject(serverUrl, sessionId, projectId)
             }
@@ -159,9 +160,6 @@ class SessionRepository(
 }
 
 private const val ARCHIVED_SYNC_LIMIT = 2_000
-
-private fun com.uzairansar.hermex.core.model.SessionMutationResponse.isSuccessfulMutation(): Boolean =
-    ok != false && error.isNullOrBlank()
 
 private fun Throwable.isCacheFallbackEligible(): Boolean = when (this) {
     is ApiError.Network -> true

--- a/android/app/src/main/java/com/uzairansar/hermex/data/secure/SecretStore.kt
+++ b/android/app/src/main/java/com/uzairansar/hermex/data/secure/SecretStore.kt
@@ -54,7 +54,10 @@ class AndroidSecretStore(context: Context) : SecretStore {
     private fun loadSecretsOrMigrate(): Map<String, String> {
         preferences.getString(PAYLOAD_KEY, null)?.let(::decryptPayload)?.let { return it }
         val migrated = migrateLegacyPreferences()
-        if (migrated.isNotEmpty()) persist(migrated)
+        if (migrated.isNotEmpty()) {
+            persist(migrated)
+            clearLegacyStorage()
+        }
         return migrated
     }
 
@@ -110,6 +113,14 @@ class AndroidSecretStore(context: Context) : SecretStore {
         return createLegacyPreferences().all.mapNotNull { (key, value) ->
             (value as? String)?.let { key to it }
         }.toMap()
+    }
+
+    private fun clearLegacyStorage() {
+        runCatching { appContext.deleteSharedPreferences(LEGACY_PREFERENCES_NAME) }
+        runCatching {
+            val keyStore = KeyStore.getInstance(ANDROID_KEY_STORE).apply { load(null) }
+            if (keyStore.containsAlias(LEGACY_KEY_ALIAS)) keyStore.deleteEntry(LEGACY_KEY_ALIAS)
+        }
     }
 
     @Suppress("DEPRECATION")

--- a/android/app/src/main/java/com/uzairansar/hermex/ui/ExportCache.kt
+++ b/android/app/src/main/java/com/uzairansar/hermex/ui/ExportCache.kt
@@ -13,7 +13,7 @@ internal fun Context.createExportDirectory(prefix: String): File {
         .filter(File::isDirectory)
         .sortedByDescending(File::lastModified)
         .forEachIndexed { index, directory ->
-            if (directory.lastModified() < cutoff || index >= EXPORT_DIRECTORY_LIMIT) {
+            if (directory.lastModified() < cutoff || index >= EXPORT_DIRECTORY_LIMIT - 1) {
                 runCatching { directory.deleteRecursively() }
             }
         }

--- a/android/app/src/main/java/com/uzairansar/hermex/ui/chat/ChatRoute.kt
+++ b/android/app/src/main/java/com/uzairansar/hermex/ui/chat/ChatRoute.kt
@@ -71,6 +71,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -2352,8 +2353,11 @@ private fun ContextWindowDetailsSheet(
     snapshot: ContextWindowSnapshot,
     onDismiss: () -> Unit,
 ) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     ModalBottomSheet(
         onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        sheetGesturesEnabled = false,
         dragHandle = null,
         containerColor = MaterialTheme.colorScheme.background,
         contentColor = MaterialTheme.colorScheme.onBackground,
@@ -3141,8 +3145,11 @@ private fun PickerSheet(
     content: @Composable () -> Unit,
 ) {
     val sheetShape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp)
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     ModalBottomSheet(
         onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        sheetGesturesEnabled = false,
         dragHandle = null,
         containerColor = Color.Transparent,
         contentColor = MaterialTheme.colorScheme.onBackground,
@@ -3157,7 +3164,8 @@ private fun PickerSheet(
                 .hermexGlass(
                     shape = sheetShape,
                     surfaceLevel = HermexSurfaceLevel.Floating,
-                ),
+                )
+                .testTag("picker_sheet"),
         ) {
             Box(
                 modifier = Modifier
@@ -3626,8 +3634,11 @@ private fun EditMessageSheet(
     onDismiss: () -> Unit,
     onSubmit: () -> Unit,
 ) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     ModalBottomSheet(
         onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        sheetGesturesEnabled = false,
         dragHandle = null,
         containerColor = MaterialTheme.colorScheme.background,
         contentColor = MaterialTheme.colorScheme.onBackground,
@@ -4689,8 +4700,11 @@ private fun GitTurnDiffSheet(
         isLoading = false
     }
 
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     ModalBottomSheet(
         onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        sheetGesturesEnabled = false,
         dragHandle = null,
         containerColor = MaterialTheme.colorScheme.background,
     ) {
@@ -5080,7 +5094,12 @@ private fun MessageActionSheet(
     onFork: () -> Unit,
     onDismiss: () -> Unit,
 ) {
-    ModalBottomSheet(onDismissRequest = onDismiss) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        sheetGesturesEnabled = false,
+    ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()

--- a/android/app/src/main/java/com/uzairansar/hermex/ui/chat/ChatViewModel.kt
+++ b/android/app/src/main/java/com/uzairansar/hermex/ui/chat/ChatViewModel.kt
@@ -34,6 +34,10 @@ import com.uzairansar.hermex.core.model.WorkspaceRoot
 import com.uzairansar.hermex.core.model.WorkspacesResponse
 import com.uzairansar.hermex.core.model.compressionAnchorMetadata
 import com.uzairansar.hermex.core.model.contextWindowSnapshot
+import com.uzairansar.hermex.core.model.isConfirmedClarification
+import com.uzairansar.hermex.core.model.isConfirmedMutation
+import com.uzairansar.hermex.core.model.isConfirmedPersonalityMutation
+import com.uzairansar.hermex.core.model.isConfirmedYoloMutation
 import com.uzairansar.hermex.core.network.SseEvent
 import com.uzairansar.hermex.core.network.HermesJson
 import com.uzairansar.hermex.data.repository.ChatSessionSnapshot
@@ -110,6 +114,14 @@ internal object StreamRecoveryBackoffPolicy {
 internal object AttachmentLimitPolicy {
     fun remaining(maximum: Int, attached: Int, uploadsInFlight: Int): Int =
         (maximum - attached - uploadsInFlight).coerceAtLeast(0)
+}
+
+internal object ChatDraftPersistencePolicy {
+    const val DebounceMillis = 300L
+    const val MaximumPersistedCharacters = 64 * 1_024
+
+    fun persistedDraft(value: String): String =
+        value.takeIf { it.length <= MaximumPersistedCharacters }.orEmpty()
 }
 
 internal object QueuedDraftRegistry {
@@ -355,6 +367,8 @@ class ChatViewModel internal constructor(
     private var pendingStreamingAssistantText: String = ""
     private var streamRecoveryJob: Job? = null
     private var streamRecoveryAttempt = 0
+    private var completedResponseStreamId: String? = null
+    private var completedResponseTitleOverride: String? = null
     private var sendStartJob: Job? = null
     private var sendStartGeneration = 0L
     private var cancelledSendStartGeneration: Long? = null
@@ -380,6 +394,7 @@ class ChatViewModel internal constructor(
     private var pendingPromptJob: Job? = null
     private var workspaceSuggestionsJob: Job? = null
     private var workspaceSuggestionsGeneration = 0L
+    private var draftPersistenceJob: Job? = null
     private val backgroundPromptsByTaskId = mutableMapOf<String, BackgroundTaskState>()
     private val pendingLocalUploads = linkedMapOf<String, PendingLocalAttachmentUpload>()
     private val queuedSlashMessages = ArrayDeque<QueuedDraft>()
@@ -407,13 +422,20 @@ class ChatViewModel internal constructor(
 
     fun updateDraft(value: String) {
         _state.update { it.copy(draft = value, error = null, notice = null) }
-        persistPendingState()
+        draftPersistenceJob?.cancel()
+        draftPersistenceJob = viewModelScope.launch {
+            delay(ChatDraftPersistencePolicy.DebounceMillis)
+            persistPendingState()
+            draftPersistenceJob = null
+        }
     }
     fun updateClarificationDraft(value: String) = _state.update { it.copy(clarificationDraft = value, error = null) }
     fun consumeOpenSession() = _state.update { it.copy(openSessionId = null) }
 
     override fun onCleared() {
         isClearing = true
+        draftPersistenceJob?.cancel()
+        runCatching { persistPendingState(durable = true) }
         streamJob?.cancel()
         streamPacingJob?.cancel()
         streamRecoveryJob?.cancel()
@@ -1416,8 +1438,8 @@ class ChatViewModel internal constructor(
     fun undoLastExchange() {
         sessionAction("Undo is available after the current response finishes.") {
             val response = repository.undoSession(sessionId)
-            if (response.error != null) {
-                SessionActionResult(error = response.error)
+            if (!response.isConfirmedMutation()) {
+                SessionActionResult(error = response.error ?: "The server did not confirm the undo.")
             } else {
                 load()
                 SessionActionResult(notice = "Undid ${response.removedCount ?: 1} message(s).")
@@ -1434,8 +1456,13 @@ class ChatViewModel internal constructor(
             _state.update { it.copy(isRunningSessionAction = true, error = null, notice = null) }
             runSuspendCatching { repository.retrySession(sessionId) }
                 .onSuccess { response ->
-                    if (response.error != null) {
-                        _state.update { it.copy(isRunningSessionAction = false, error = response.error) }
+                    if (!response.isConfirmedMutation()) {
+                        _state.update {
+                            it.copy(
+                                isRunningSessionAction = false,
+                                error = response.error ?: "The server did not confirm the retry.",
+                            )
+                        }
                         return@onSuccess
                     }
                     val lastUserText = response.lastUserText?.trim().orEmpty()
@@ -1649,8 +1676,8 @@ class ChatViewModel internal constructor(
     fun compressContext(focusTopic: String? = null) {
         sessionAction("Wait for the current response to finish before compressing context.") {
             val response = repository.compressSession(sessionId, focusTopic?.trim()?.ifBlank { null })
-            if (response.error != null) {
-                SessionActionResult(error = response.error)
+            if (!response.isConfirmedMutation()) {
+                SessionActionResult(error = response.error ?: "The server did not confirm context compression.")
             } else {
                 response.session?.let { session ->
                     val messages = session.messages.orEmpty()
@@ -1932,9 +1959,9 @@ class ChatViewModel internal constructor(
             val cancelError = runSuspendCatching { repository.cancel(streamId) }
                 .fold(
                     onSuccess = { response ->
-                        completedBeforeCancellation = response.cancelled == false && response.error.isNullOrBlank()
+                        completedBeforeCancellation = response.isConfirmedMutation() && response.cancelled == false
                         response.error?.takeIf { it.isNotBlank() }
-                            ?: if (response.ok == false) "The server could not cancel this response." else null
+                            ?: if (!response.isConfirmedMutation()) "The server could not cancel this response." else null
                     },
                     onFailure = { it.message ?: "Could not cancel the response." },
                 )
@@ -1975,7 +2002,7 @@ class ChatViewModel internal constructor(
         withContext(NonCancellable + Dispatchers.IO) {
             val response = runSuspendCatching { repository.cancel(streamId) }.getOrNull()
             repository.clearStreamCursor(streamId)
-            response?.cancelled == false && response.error.isNullOrBlank()
+            response?.isConfirmedMutation() == true && response.cancelled == false
         }
 
     private fun discardActiveStreamAfterSessionClear() {
@@ -2114,7 +2141,7 @@ class ChatViewModel internal constructor(
                     val kickoff = response.kickoffPrompt?.trim().orEmpty()
                     val responseError = response.error?.takeIf { it.isNotBlank() }
                     val responseSessionId = response.sessionId?.trim()?.takeIf { it.isNotBlank() }
-                    if (response.ok == false || response.action.equals("error", ignoreCase = true) || responseError != null) {
+                    if (!response.isConfirmedMutation()) {
                         _state.update {
                             it.copy(
                                 isRunningSessionAction = false,
@@ -2399,6 +2426,15 @@ class ChatViewModel internal constructor(
             _state.update { it.copy(isRunningSessionAction = true, draft = "", error = null, notice = null) }
             runSuspendCatching { repository.renameSession(sessionId, title) }
                 .onSuccess { response ->
+                    if (!response.isConfirmedMutation()) {
+                        _state.update {
+                            it.copy(
+                                isRunningSessionAction = false,
+                                error = response.error ?: "The server did not confirm the title change.",
+                            )
+                        }
+                        return@onSuccess
+                    }
                     val newTitle = response.session?.title?.trim()?.takeIf { it.isNotBlank() } ?: title
                     _state.update {
                         it.copy(
@@ -2480,7 +2516,7 @@ class ChatViewModel internal constructor(
                     return@launch
                 }
                 val cancelError = cancelResponse.error?.takeIf { it.isNotBlank() }
-                    ?: if (cancelResponse.ok == false) "Could not stop the previous side question." else null
+                    ?: if (!cancelResponse.isConfirmedMutation()) "Could not stop the previous side question." else null
                 if (cancelError != null) {
                     _state.update { it.copy(isRunningSessionAction = false, error = cancelError) }
                     return@launch
@@ -2550,7 +2586,7 @@ class ChatViewModel internal constructor(
                         btwStreamOwnerId = null
                         btwJob = null
                     }
-                    SseEvent.Cancelled -> {
+                    is SseEvent.Cancelled -> {
                         updateLocalAssistant(messageId, btwMessageText(question, answer, isLoading = false))
                         persistBtwTask(null)
                         btwStreamOwnerId = null
@@ -2685,7 +2721,7 @@ class ChatViewModel internal constructor(
     private fun persistPendingState(durable: Boolean = false) {
         pendingStateStore?.save(
             PersistedChatPendingState(
-                draft = _state.value.draft,
+                draft = ChatDraftPersistencePolicy.persistedDraft(_state.value.draft),
                 pendingAttachments = _state.value.pendingAttachments,
                 pendingLocalUploads = pendingLocalUploads.values.toList(),
                 queuedDrafts = queuedSlashMessages.toList(),
@@ -2777,8 +2813,14 @@ class ChatViewModel internal constructor(
             _state.update { it.copy(isRunningSessionAction = true, draft = "", error = null, notice = null) }
             runSuspendCatching { repository.setPersonality(sessionId, name) }
                 .onSuccess { response ->
-                    if (response.error != null) {
-                        _state.update { it.copy(isRunningSessionAction = false, error = response.error) }
+                    if (!response.isConfirmedPersonalityMutation(name)) {
+                        _state.update {
+                            it.copy(
+                                isRunningSessionAction = false,
+                                error = response.error?.takeIf { message -> message.isNotBlank() }
+                                    ?: "The server did not confirm the personality change.",
+                            )
+                        }
                         return@onSuccess
                     }
                     _state.update { it.copy(isRunningSessionAction = false) }
@@ -2839,7 +2881,7 @@ class ChatViewModel internal constructor(
             runSuspendCatching {
                 repository.respondApproval(sessionId, choice, approval.normalizedApprovalId)
             }.onSuccess { response ->
-                if (response.ok == false && response.staleCleared != true && response.staleClearedSnake != true) {
+                if (!response.isConfirmedMutation()) {
                     _state.update {
                         it.copy(
                             isRespondingToPendingPrompt = false,
@@ -2871,7 +2913,7 @@ class ChatViewModel internal constructor(
             runSuspendCatching { repository.setSessionYolo(sessionId, enabled = true) }
                 .onSuccess { response ->
                     val responseError = response.error?.takeIf { it.isNotBlank() }
-                    if (response.ok == false || responseError != null) {
+                    if (!response.isConfirmedYoloMutation(enabled = true)) {
                         _state.update {
                             it.copy(
                                 isRespondingToPendingPrompt = false,
@@ -2882,7 +2924,7 @@ class ChatViewModel internal constructor(
                     }
                     _state.update {
                         it.copy(
-                            isSessionApprovalBypassEnabled = response.yoloEnabled ?: response.yoloEnabledSnake ?: true,
+                            isSessionApprovalBypassEnabled = true,
                             pendingApproval = null,
                             pendingApprovalCount = 0,
                             isRespondingToPendingPrompt = false,
@@ -2924,6 +2966,16 @@ class ChatViewModel internal constructor(
             runSuspendCatching {
                 repository.respondClarification(sessionId, trimmed, clarification.normalizedClarifyId)
             }.onSuccess { serverResponse ->
+                if (!serverResponse.isConfirmedClarification(trimmed)) {
+                    _state.update {
+                        it.copy(
+                            isRespondingToPendingPrompt = false,
+                            error = "The server did not accept that clarification response.",
+                        )
+                    }
+                    refreshPendingPrompts()
+                    return@onSuccess
+                }
                 _state.update {
                     it.copy(
                         pendingClarification = null,
@@ -2945,6 +2997,9 @@ class ChatViewModel internal constructor(
         replayAfterSeq: Int? = null,
         cancelRecovery: Boolean = true,
     ) {
+        if (completedResponseStreamId != streamId) {
+            completedResponseTitleOverride = null
+        }
         if (cancelRecovery) {
             streamRecoveryJob?.cancel()
             streamRecoveryJob = null
@@ -2961,6 +3016,9 @@ class ChatViewModel internal constructor(
         streamJob = viewModelScope.launch {
             repository.stream(streamId, replayAfterSeq)
                 .onCompletion { cause ->
+                    if (completedResponseStreamId == streamId) {
+                        completedResponseStreamId = null
+                    }
                     if (
                         !_state.value.isRecoveringStream &&
                         ChatStreamRecoveryPolicy.shouldRecoverAfterFlowCompletion(
@@ -2974,7 +3032,7 @@ class ChatViewModel internal constructor(
                     }
                 }
                 .collect { event ->
-                if (!ChatStreamOwnershipPolicy.stillOwnsStream(streamId, _state.value.activeStreamId)) return@collect
+                if (!ownsStreamTransport(streamId)) return@collect
                 when (event) {
                     is SseEvent.Token -> {
                         val tokenText = if (replayAfterSeq == 0) {
@@ -3014,6 +3072,7 @@ class ChatViewModel internal constructor(
                         clearStreamRecoveryState()
                         if (event.sessionId.isNullOrBlank() || event.sessionId == sessionId) {
                             event.title?.trim()?.takeIf { it.isNotBlank() }?.let { title ->
+                                completedResponseTitleOverride = title
                                 _state.update { it.copy(sessionTitle = title) }
                             }
                         }
@@ -3024,17 +3083,31 @@ class ChatViewModel internal constructor(
                     }
                     SseEvent.StreamEnd -> {
                         flushPendingStreamingAssistant()
-                        finishStream(
-                            needsTranscriptRefresh = assistantText.isBlank() || reconcileFinalTranscriptForStreamId == streamId,
-                        )
+                        if (completedResponseStreamId == streamId) {
+                            finishCompletedStreamTransport(streamId)
+                        } else {
+                            finishStream(
+                                needsTranscriptRefresh = assistantText.isBlank() || reconcileFinalTranscriptForStreamId == streamId,
+                            )
+                        }
                     }
-                    SseEvent.Cancelled -> {
+                    is SseEvent.Cancelled -> {
                         flushPendingStreamingAssistant()
-                        finishTerminalStream(streamId)
+                        reconcileTerminalStream(
+                            streamId = streamId,
+                            session = event.session,
+                            replacementSessionId = event.replacementSessionId,
+                            error = null,
+                        )
                     }
                     is SseEvent.Error -> {
                         flushPendingStreamingAssistant()
-                        finishTerminalStream(streamId, event.message)
+                        reconcileTerminalStream(
+                            streamId = streamId,
+                            session = event.session,
+                            replacementSessionId = event.replacementSessionId,
+                            error = event.displayMessage,
+                        )
                     }
                     is SseEvent.TransportError -> {
                         flushPendingStreamingAssistant()
@@ -3359,9 +3432,10 @@ class ChatViewModel internal constructor(
     }
 
     private fun finishTerminalStream(streamId: String, error: String? = null) {
-        if (!ChatStreamOwnershipPolicy.stillOwnsStream(streamId, _state.value.activeStreamId)) return
+        if (!ownsStreamTransport(streamId)) return
         flushPendingStreamingAssistant()
         if (reconcileFinalTranscriptForStreamId == streamId) reconcileFinalTranscriptForStreamId = null
+        if (completedResponseStreamId == streamId) completedResponseStreamId = null
         repository.clearStreamCursor(streamId)
         streamRecoveryJob?.cancel()
         streamRecoveryJob = null
@@ -3383,19 +3457,22 @@ class ChatViewModel internal constructor(
     private suspend fun completeStream(streamId: String, event: SseEvent.Done) {
         if (!ChatStreamOwnershipPolicy.stillOwnsStream(streamId, _state.value.activeStreamId)) return
         flushPendingStreamingAssistant()
-        val completedSession = event.session?.takeIf { completed ->
-            completed.sessionId.isNullOrBlank() || completed.sessionId == sessionId
-        }
+        val completedSession = event.session
         val completedTranscript = completedSession?.takeIf { it.messages?.isNotEmpty() == true }
         if (completedTranscript != null) {
             val snapshot = repository.snapshotFromCompletedSession(sessionId, completedTranscript, streamId)
             if (!ChatStreamOwnershipPolicy.stillOwnsStream(streamId, _state.value.activeStreamId)) return
-            applySessionSnapshot(snapshot) {
-                it.copy(
-                    isStreaming = false,
-                    activeStreamId = null,
-                    responseCompletionNeedsTranscriptRefresh = false,
-                )
+            val completedSessionId = completedTranscript.sessionId?.trim()?.takeIf { it.isNotBlank() }
+            if (completedSessionId == null || completedSessionId == sessionId) {
+                applySessionSnapshot(snapshot) {
+                    it.copy(
+                        isStreaming = true,
+                        activeStreamId = streamId,
+                        responseCompletionNeedsTranscriptRefresh = false,
+                    )
+                }
+            } else {
+                _state.update { it.copy(openSessionId = completedSessionId) }
             }
         }
         event.usage?.let { usage ->
@@ -3403,21 +3480,93 @@ class ChatViewModel internal constructor(
             _state.update { it.copy(contextWindowSnapshot = usage) }
         }
         if (!ChatStreamOwnershipPolicy.stillOwnsStream(streamId, _state.value.activeStreamId)) return
-        finishStream(needsTranscriptRefresh = completedTranscript == null)
+        completeCurrentResponse(streamId, needsTranscriptRefresh = completedTranscript == null)
+    }
+
+    private suspend fun reconcileTerminalStream(
+        streamId: String,
+        session: com.uzairansar.hermex.core.model.SessionDetail?,
+        replacementSessionId: String?,
+        error: String?,
+    ) {
+        if (!ownsStreamTransport(streamId)) return
+        val resolvedSessionId = replacementSessionId?.trim()?.takeIf { it.isNotBlank() }
+            ?: session?.sessionId?.trim()?.takeIf { it.isNotBlank() }
+        if (session != null) {
+            val snapshot = repository.snapshotFromCompletedSession(sessionId, session, streamId)
+            if (!ownsStreamTransport(streamId)) return
+            if (resolvedSessionId == null || resolvedSessionId == sessionId) {
+                applySessionSnapshot(snapshot) {
+                    it.copy(isStreaming = true, activeStreamId = streamId)
+                }
+            }
+        }
+        if (resolvedSessionId != null && resolvedSessionId != sessionId) {
+            _state.update { it.copy(openSessionId = resolvedSessionId) }
+        }
+        finishTerminalStream(streamId, error)
+    }
+
+    private fun completeCurrentResponse(streamId: String, needsTranscriptRefresh: Boolean) {
+        if (!ChatStreamOwnershipPolicy.stillOwnsStream(streamId, _state.value.activeStreamId)) return
+        completedResponseStreamId = streamId
+        reconcileFinalTranscriptForStreamId = null
+        repository.clearStreamCursor(streamId)
+        streamRecoveryJob?.cancel()
+        streamRecoveryJob = null
+        streamRecoveryAttempt = 0
+        stopPendingPromptPolling(clearPrompts = true)
+        _state.update {
+            it.copy(
+                isStreaming = false,
+                activeStreamRecoveryState = ActiveStreamRecoveryState.Idle,
+                activeStreamId = null,
+                responseCompletionTrigger = it.responseCompletionTrigger + 1,
+                responseCompletionNeedsTranscriptRefresh = needsTranscriptRefresh,
+                liveReasoning = "",
+                liveToolActivity = null,
+                pendingApproval = null,
+                pendingClarification = null,
+            )
+        }
+        drainQueuedSlashMessageIfIdle()
+    }
+
+    private fun finishCompletedStreamTransport(streamId: String) {
+        if (completedResponseStreamId != streamId) return
+        completedResponseStreamId = null
+        streamJob = null
     }
 
     fun refreshCompletedTranscriptIfNeeded() {
         if (!_state.value.responseCompletionNeedsTranscriptRefresh) return
         if (completedTranscriptRefreshJob?.isActive == true) return
+        val completionTrigger = _state.value.responseCompletionTrigger
         completedTranscriptRefreshJob = viewModelScope.launch {
             repeat(COMPLETED_TRANSCRIPT_REFRESH_ATTEMPTS) { attempt ->
-                if (!_state.value.responseCompletionNeedsTranscriptRefresh) return@launch
+                if (
+                    !_state.value.responseCompletionNeedsTranscriptRefresh ||
+                    _state.value.responseCompletionTrigger != completionTrigger ||
+                    _state.value.isStreaming
+                ) {
+                    return@launch
+                }
                 when (val result = repository.loadSessionSnapshot(sessionId)) {
                     is ResultState.Data -> {
+                        if (
+                            _state.value.responseCompletionTrigger != completionTrigger ||
+                            _state.value.isStreaming
+                        ) {
+                            return@launch
+                        }
                         if (!result.fromCache && result.value.messages.hasAssistantResponseAfterLatestUser()) {
                             applySessionSnapshot(result.value, fromCache = false) {
-                                it.copy(responseCompletionNeedsTranscriptRefresh = false)
+                                it.copy(
+                                    sessionTitle = completedResponseTitleOverride ?: it.sessionTitle,
+                                    responseCompletionNeedsTranscriptRefresh = false,
+                                )
                             }
+                            completedResponseTitleOverride = null
                             return@launch
                         }
                     }
@@ -3433,6 +3582,7 @@ class ChatViewModel internal constructor(
     private fun finishStream(needsTranscriptRefresh: Boolean = false) {
         flushPendingStreamingAssistant()
         reconcileFinalTranscriptForStreamId = null
+        completedResponseStreamId = null
         _state.value.activeStreamId?.let(repository::clearStreamCursor)
         streamJob?.cancel()
         streamRecoveryJob?.cancel()
@@ -3454,6 +3604,20 @@ class ChatViewModel internal constructor(
         }
         drainQueuedSlashMessageIfIdle()
     }
+
+    private fun ownsStreamTransport(streamId: String): Boolean =
+        ChatStreamOwnershipPolicy.stillOwnsStream(streamId, _state.value.activeStreamId) ||
+            completedResponseStreamId == streamId
+
+    private val SseEvent.Error.displayMessage: String
+        get() = listOfNotNull(
+            message.trim().takeIf { it.isNotBlank() },
+            hint?.trim()?.takeIf { it.isNotBlank() },
+            details?.trim()?.takeIf { it.isNotBlank() && it != message.trim() },
+        )
+            .distinct()
+            .joinToString("\n\n")
+            .take(MAXIMUM_STREAM_ERROR_CHARACTERS)
 
     private fun List<ChatMessage>.hasAssistantResponseAfterLatestUser(): Boolean {
         val latestUserIndex = indexOfLast { it.role == "user" }
@@ -3647,6 +3811,7 @@ private fun File.isInside(directory: File): Boolean {
         const val STREAM_RECOVERY_RETRY_DELAY_MS = 750L
         const val STREAM_RECOVERY_MAX_DELAY_MS = 12_000L
         const val MAXIMUM_STREAM_RECOVERY_ATTEMPTS = 6
+        const val MAXIMUM_STREAM_ERROR_CHARACTERS = 4_000
         const val COMPLETED_TRANSCRIPT_REFRESH_DELAY_MS = 500L
         const val COMPLETED_TRANSCRIPT_REFRESH_ATTEMPTS = 6
         const val STREAMING_INITIAL_REVEAL_DELAY_MS = 16L

--- a/android/app/src/main/java/com/uzairansar/hermex/ui/chat/MarkdownText.kt
+++ b/android/app/src/main/java/com/uzairansar/hermex/ui/chat/MarkdownText.kt
@@ -71,6 +71,7 @@ import io.noties.markwon.syntax.Prism4jThemeDarkula
 import io.noties.markwon.syntax.Prism4jThemeDefault
 import io.noties.markwon.syntax.SyntaxHighlightPlugin
 import io.noties.prism4j.Prism4j
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -95,11 +96,11 @@ fun MarkdownText(
         }
         return
     }
-    if (markdown.length > MAX_STRUCTURED_MARKDOWN_CHARACTERS) {
-        val chunks = remember(markdown) { markdownPlainTextChunks(markdown, PLAIN_TEXT_CHUNK_CHARACTERS) }
+    val plainTextChunks = remember(markdown) { markdownPlainTextChunksForLargeContent(markdown) }
+    if (plainTextChunks != null) {
         SelectionContainer {
             Column(modifier = modifier) {
-                chunks.forEach { chunk ->
+                plainTextChunks.forEach { chunk ->
                     Text(
                         text = chunk,
                         style = MaterialTheme.typography.bodyMedium,
@@ -112,7 +113,13 @@ fun MarkdownText(
     }
     var parsedSegments by remember { mutableStateOf<List<MarkdownSegment>?>(null) }
     LaunchedEffect(markdown) {
-        parsedSegments = withContext(Dispatchers.Default) { markdown.parseMarkdownSegments() }
+        parsedSegments = try {
+            withContext(Dispatchers.Default) { markdown.parseMarkdownSegments() }
+        } catch (error: CancellationException) {
+            throw error
+        } catch (_: Exception) {
+            listOf(MarkdownSegment.Markdown(markdown))
+        }
     }
     val segments = parsedSegments ?: listOf(MarkdownSegment.Markdown(markdown))
     if (segments.size == 1 && segments.single() is MarkdownSegment.Markdown) {
@@ -175,10 +182,17 @@ private const val STREAMING_SUFFIX_START_ALPHA = 72
 private const val MAX_STRUCTURED_MARKDOWN_CHARACTERS = 80_000
 private const val PLAIN_TEXT_CHUNK_CHARACTERS = 16_000
 
+internal fun markdownPlainTextChunksForLargeContent(markdown: String): List<String>? =
+    if (markdown.length > MAX_STRUCTURED_MARKDOWN_CHARACTERS) {
+        markdownPlainTextChunks(markdown, PLAIN_TEXT_CHUNK_CHARACTERS)
+    } else {
+        null
+    }
+
 internal fun markdownPlainTextChunks(markdown: String, maximumCharacters: Int): List<String> {
     if (markdown.isEmpty()) return listOf("")
     val chunkSize = maximumCharacters.coerceAtLeast(1)
-    val chunks = ArrayList<String>((markdown.length / chunkSize) + 1)
+    val ranges = ArrayList<IntRange>((markdown.length / chunkSize) + 1)
     var start = 0
     while (start < markdown.length) {
         var end = (start + chunkSize).coerceAtMost(markdown.length)
@@ -186,10 +200,16 @@ internal fun markdownPlainTextChunks(markdown: String, maximumCharacters: Int): 
             end -= 1
         }
         if (end == start) end = (start + 2).coerceAtMost(markdown.length)
-        chunks += markdown.substring(start, end)
+        ranges += start until end
         start = end
     }
-    return chunks
+    return object : AbstractList<String>() {
+        override val size: Int = ranges.size
+        override fun get(index: Int): String {
+            val range = ranges[index]
+            return markdown.substring(range.first, range.last + 1)
+        }
+    }
 }
 
 @Composable
@@ -212,19 +232,46 @@ private fun MarkdownAndroidView(
     val isDarkTheme = colorScheme.background.luminance() < 0.5f
     val latexTextSizePx = with(LocalDensity.current) { 15.sp.toPx() }
     val markwon = remember(context, textColor, linkColor, codeBackground, dividerColor, isDarkTheme, latexTextSizePx) {
-        MarkdownRendererCache.get(
-            context = context.applicationContext,
-            textColor = textColor,
-            codeBackground = codeBackground,
-            dividerColor = dividerColor,
-            isDarkTheme = isDarkTheme,
-            latexTextSizePx = latexTextSizePx,
-        )
+        try {
+            MarkdownRendererCache.get(
+                context = context.applicationContext,
+                textColor = textColor,
+                codeBackground = codeBackground,
+                dividerColor = dividerColor,
+                isDarkTheme = isDarkTheme,
+                latexTextSizePx = latexTextSizePx,
+            )
+        } catch (_: Exception) {
+            null
+        }
     }
-    var parsedMarkdown by remember(markwon) { mutableStateOf<android.text.Spanned?>(null) }
+    var renderState by remember(markwon, markdown) { mutableStateOf<MarkdownRenderState>(MarkdownRenderState.Pending) }
     LaunchedEffect(markwon, markdown) {
-        parsedMarkdown = withContext(Dispatchers.Default) { markwon.toMarkdown(markdown) }
+        if (markwon == null) {
+            renderState = MarkdownRenderState.Failed
+            return@LaunchedEffect
+        }
+        renderState = try {
+            MarkdownRenderState.Rendered(withContext(Dispatchers.Default) { markwon.toMarkdown(markdown) })
+        } catch (error: CancellationException) {
+            throw error
+        } catch (_: Exception) {
+            MarkdownRenderState.Failed
+        }
     }
+    val parsedMarkdown = (renderState as? MarkdownRenderState.Rendered)?.markdown
+    if (parsedMarkdown == null) {
+        SelectionContainer {
+            Text(
+                text = markdown,
+                modifier = modifier,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+        return
+    }
+    val renderer = markwon ?: return
     AndroidView(
         modifier = modifier.semantics {
             text = AnnotatedString(markdown)
@@ -243,25 +290,39 @@ private fun MarkdownAndroidView(
             textView.setLinkTextColor(linkColor)
             textView.setHorizontallyScrolling(false)
             textView.isHorizontalScrollBarEnabled = false
-            parsedMarkdown?.let { parsed ->
+            parsedMarkdown.let { parsed ->
                 val viewState = textView.tag as? StreamingMarkdownViewState
                     ?: StreamingMarkdownViewState().also { textView.tag = it }
                 val nextText = parsed.toString()
-                if (viewState.renderer === markwon && viewState.renderedText == nextText) return@let
+                if (viewState.renderer === renderer && viewState.renderedText == nextText) return@let
                 viewState.animator?.cancel()
                 val suffixStart = streamingSuffixStart(viewState.previousText, nextText)
                 val spannable = SpannableStringBuilder(parsed)
-                markwon.setParsedMarkdown(textView, spannable)
+                try {
+                    renderer.setParsedMarkdown(textView, spannable)
+                } catch (_: Exception) {
+                    textView.text = markdown
+                    viewState.previousText = markdown
+                    viewState.renderedText = markdown
+                    viewState.renderer = null
+                    return@let
+                }
                 val displayedText = textView.text as? Spannable ?: spannable
                 if (isStreaming && streamedTextAnimationEnabled && suffixStart < displayedText.length) {
                     animateStreamingSuffix(textView, displayedText, suffixStart, textColor, viewState)
                 }
                 viewState.previousText = nextText
                 viewState.renderedText = nextText
-                viewState.renderer = markwon
+                viewState.renderer = renderer
             }
         },
     )
+}
+
+private sealed interface MarkdownRenderState {
+    data object Pending : MarkdownRenderState
+    data object Failed : MarkdownRenderState
+    data class Rendered(val markdown: Spanned) : MarkdownRenderState
 }
 
 internal fun streamingSuffixStart(previous: String, current: String): Int {

--- a/android/app/src/main/java/com/uzairansar/hermex/ui/chat/StreamRecoveryService.kt
+++ b/android/app/src/main/java/com/uzairansar/hermex/ui/chat/StreamRecoveryService.kt
@@ -160,7 +160,11 @@ class StreamRecoveryService : Service() {
     }
 
     private fun stopIfNoActiveJobs() {
-        if (jobs.isNotEmpty()) return
+        val records = store.records()
+        if (!streamRecoveryShouldStop(jobs.size, records.size)) {
+            records.firstOrNull()?.let(::ensureForeground)
+            return
+        }
         stopForeground(STOP_FOREGROUND_REMOVE)
         stopSelf()
     }
@@ -344,6 +348,9 @@ internal fun streamRecoveryRetryDelayMillis(consecutiveFailures: Int): Long {
 }
 
 internal fun streamRecoveryShouldRetry(consecutiveFailures: Int): Boolean = consecutiveFailures > 0
+
+internal fun streamRecoveryShouldStop(activeJobCount: Int, durableRecordCount: Int): Boolean =
+    activeJobCount == 0 && durableRecordCount == 0
 
 internal fun streamRecoveryRecordExpired(startedAtMillis: Long, nowMillis: Long): Boolean =
     nowMillis - startedAtMillis >= MAX_STREAM_RECOVERY_AGE_MILLIS

--- a/android/app/src/main/java/com/uzairansar/hermex/ui/git/GitResponsePolicy.kt
+++ b/android/app/src/main/java/com/uzairansar/hermex/ui/git/GitResponsePolicy.kt
@@ -6,19 +6,27 @@ import com.uzairansar.hermex.core.model.GitCommitResponse
 import com.uzairansar.hermex.core.model.GitMutationResponse
 
 internal fun GitMutationResponse.failureMessage(fallback: String): String? =
-    error.nonBlankOrNull() ?: fallback.takeIf { ok == false }
+    error.nonBlankOrNull() ?: fallback.takeUnless {
+        ok != false && (ok == true || status != null || git != null || message.nonBlankOrNull() != null)
+    }
 
 internal fun GitCommitResponse.failureMessage(fallback: String): String? =
-    error.nonBlankOrNull() ?: fallback.takeIf { ok == false }
+    error.nonBlankOrNull() ?: fallback.takeUnless {
+        ok != false && (ok == true || sha.nonBlankOrNull() != null || shortSha.nonBlankOrNull() != null)
+    }
 
 internal fun GitCommitMessageResponse.failureMessage(fallback: String): String? =
-    error.nonBlankOrNull() ?: fallback.takeIf { ok == false }
+    error.nonBlankOrNull() ?: fallback.takeUnless {
+        ok != false && (ok == true || message.nonBlankOrNull() != null)
+    }
 
 internal fun GitCheckoutResponse.failureMessage(fallback: String): String? =
     error.nonBlankOrNull()
         ?: restoreError.nonBlankOrNull()
         ?: "The server could not restore the stashed changes.".takeIf { restoreFailed == true }
-        ?: fallback.takeIf { ok == false }
+        ?: fallback.takeUnless {
+            ok != false && (ok == true || status != null || git != null || branches != null || currentBranch.nonBlankOrNull() != null)
+        }
 
 private fun String?.nonBlankOrNull(): String? = this?.trim()?.take(MAXIMUM_GIT_ERROR_CHARACTERS)?.takeIf { it.isNotEmpty() }
 

--- a/android/app/src/main/java/com/uzairansar/hermex/ui/panels/PanelsRoute.kt
+++ b/android/app/src/main/java/com/uzairansar/hermex/ui/panels/PanelsRoute.kt
@@ -23,8 +23,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Checkbox
@@ -45,6 +47,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontFamily
@@ -86,6 +89,7 @@ import com.uzairansar.hermex.core.model.SkillContentResponse
 import com.uzairansar.hermex.core.model.SkillSummary
 import com.uzairansar.hermex.data.repository.PanelsRepository
 import com.uzairansar.hermex.ui.chat.MarkdownText
+import com.uzairansar.hermex.ui.chat.markdownPlainTextChunksForLargeContent
 import com.uzairansar.hermex.ui.theme.HermexCardShape
 import com.uzairansar.hermex.ui.theme.HermexGlassShape
 import com.uzairansar.hermex.ui.theme.HermexIconButton
@@ -1046,8 +1050,11 @@ private fun TaskDetailSheet(
     onEdit: () -> Unit,
     onDelete: () -> Unit,
 ) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     ModalBottomSheet(
         onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        sheetGesturesEnabled = false,
         dragHandle = null,
         shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
         containerColor = Color.Transparent,
@@ -1061,8 +1068,8 @@ private fun TaskDetailSheet(
                     castsShadow = false,
                     surfaceLevel = HermexSurfaceLevel.Floating,
                 )
-                .padding(horizontal = 16.dp, vertical = 14.dp)
-                .verticalScroll(rememberScrollState()),
+                .testTag("task_detail_sheet")
+                .padding(horizontal = 16.dp, vertical = 14.dp),
             verticalArrangement = Arrangement.spacedBy(14.dp),
         ) {
             Row(
@@ -1124,49 +1131,59 @@ private fun TaskDetailSheet(
                 }
             }
 
-            PanelSubsection(localizedString("Details")) {
-                CronJobMetadataRow("Schedule", job.scheduleText)
-                CronJobMetadataRow("Next", job.nextRunAt.panelDateText() ?: "Not available")
-                CronJobMetadataRow("Last", job.lastRunAt.panelDateText() ?: "Never")
-                runningElapsed?.let { CronJobMetadataRow("Elapsed", elapsedText(it)) }
-                CronJobMetadataRow("Deliver", job.deliver?.takeIf { it.isNotBlank() } ?: "local")
-                job.model?.takeIf { it.isNotBlank() }?.let { CronJobMetadataRow("Model", it) }
-                job.profile?.takeIf { it.isNotBlank() }?.let { CronJobMetadataRow("Profile", it) }
-                job.toastNotifications?.let { CronJobMetadataRow("Toasts", if (it) "On" else "Off") }
-                job.skills?.takeIf { it.isNotEmpty() }?.let { CronJobMetadataRow("Skills", it.joinToString(", ")) }
-                (job.lastError ?: job.lastDeliveryError)?.takeIf { it.isNotBlank() }?.let { error ->
-                    CronJobMetadataRow("Error", error, isError = true)
-                }
-            }
-
-            PanelSubsection(localizedString("Recent Output")) {
-                when {
-                    isLoadingOutput -> Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
-                        CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
-                        Text(localizedString("Loading output..."), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.secondary)
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+                    .verticalScroll(rememberScrollState())
+                    .testTag("task_detail_scroll"),
+                verticalArrangement = Arrangement.spacedBy(14.dp),
+            ) {
+                PanelSubsection(localizedString("Details")) {
+                    CronJobMetadataRow("Schedule", job.scheduleText)
+                    CronJobMetadataRow("Next", job.nextRunAt.panelDateText() ?: "Not available")
+                    CronJobMetadataRow("Last", job.lastRunAt.panelDateText() ?: "Never")
+                    runningElapsed?.let { CronJobMetadataRow("Elapsed", elapsedText(it)) }
+                    CronJobMetadataRow("Deliver", job.deliver?.takeIf { it.isNotBlank() } ?: "local")
+                    job.model?.takeIf { it.isNotBlank() }?.let { CronJobMetadataRow("Model", it) }
+                    job.provider?.takeIf { it.isNotBlank() }?.let { CronJobMetadataRow("Provider", it) }
+                    job.profile?.takeIf { it.isNotBlank() }?.let { CronJobMetadataRow("Profile", it) }
+                    job.toastNotifications?.let { CronJobMetadataRow("Toasts", if (it) "On" else "Off") }
+                    job.skills?.takeIf { it.isNotEmpty() }?.let { CronJobMetadataRow("Skills", it.joinToString(", ")) }
+                    (job.lastError ?: job.lastDeliveryError)?.takeIf { it.isNotBlank() }?.let { error ->
+                        CronJobMetadataRow("Error", error, isError = true)
                     }
-                    output?.error?.isNotBlank() == true && output.outputs.isNullOrEmpty() -> Text(
-                        output.error,
-                        color = MaterialTheme.colorScheme.error,
-                        style = MaterialTheme.typography.bodySmall,
-                    )
-                    output?.outputs.isNullOrEmpty() -> Text(
-                        localizedString("This task has not produced any output yet."),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.secondary,
-                    )
-                    else -> output.outputs.orEmpty().forEach { item ->
-                        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-                            Text(item.filename ?: "Untitled", fontWeight = FontWeight.SemiBold, style = MaterialTheme.typography.bodySmall)
-                            Text(
-                                item.content?.takeIf { it.isNotBlank() } ?: "Empty output",
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.62f), HermexCardShape)
-                                    .padding(10.dp),
-                                fontFamily = FontFamily.Monospace,
-                                style = MaterialTheme.typography.bodySmall,
-                            )
+                }
+
+                PanelSubsection(localizedString("Recent Output")) {
+                    when {
+                        isLoadingOutput -> Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
+                            CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+                            Text(localizedString("Loading output..."), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.secondary)
+                        }
+                        output?.error?.isNotBlank() == true && output.outputs.isNullOrEmpty() -> Text(
+                            output.error,
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                        output?.outputs.isNullOrEmpty() -> Text(
+                            localizedString("This task has not produced any output yet."),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.secondary,
+                        )
+                        else -> output.outputs.orEmpty().forEach { item ->
+                            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                                Text(item.filename ?: "Untitled", fontWeight = FontWeight.SemiBold, style = MaterialTheme.typography.bodySmall)
+                                Text(
+                                    item.content?.takeIf { it.isNotBlank() } ?: "Empty output",
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.62f), HermexCardShape)
+                                        .padding(10.dp),
+                                    fontFamily = FontFamily.Monospace,
+                                    style = MaterialTheme.typography.bodySmall,
+                                )
+                            }
                         }
                     }
                 }
@@ -1548,6 +1565,13 @@ private fun TaskEditorDialog(
                     enabled = !isMutating,
                 )
                 OutlinedTextField(
+                    value = draft.provider,
+                    onValueChange = { onDraftChange(draft.copy(provider = it)) },
+                    label = { Text(localizedString("Provider")) },
+                    singleLine = true,
+                    enabled = !isMutating,
+                )
+                OutlinedTextField(
                     value = draft.profile,
                     onValueChange = { onDraftChange(draft.copy(profile = it)) },
                     label = { Text(localizedString("Profile")) },
@@ -1787,6 +1811,8 @@ private fun SkillDetailSheet(
     val density = LocalDensity.current
     val windowHeight = LocalWindowInfo.current.containerSize.height
     val sheetHeight = with(density) { windowHeight.toDp() } * 0.9f
+    val content = skill.content?.trim().orEmpty()
+    val plainTextChunks = remember(content) { markdownPlainTextChunksForLargeContent(content) }
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
@@ -1824,27 +1850,49 @@ private fun SkillDetailSheet(
                 HermexPillButton(localizedString("Done"), onDismiss, filled = true)
             }
             Spacer(Modifier.height(14.dp))
-            Column(
+            LazyColumn(
                 modifier = Modifier
                     .fillMaxWidth()
                     .weight(1f)
-                    .verticalScroll(rememberScrollState())
                     .testTag("skill_detail_scroll"),
+                contentPadding = PaddingValues(bottom = 18.dp),
             ) {
-                val content = skill.content?.trim().orEmpty()
                 when {
-                    content.isNotEmpty() -> MarkdownText(content)
-                    !skill.error.isNullOrBlank() -> Text(skill.error, color = MaterialTheme.colorScheme.error)
-                    else -> Text(localizedString("This skill has no content."), color = PanelSecondaryText)
+                    content.isNotEmpty() && plainTextChunks == null -> item("skill-markdown") {
+                        MarkdownText(content)
+                    }
+                    content.isNotEmpty() -> items(
+                        count = plainTextChunks.orEmpty().size,
+                        key = { index -> "skill-plain-$index" },
+                    ) { index ->
+                        SelectionContainer {
+                            Text(
+                                text = plainTextChunks.orEmpty()[index],
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurface,
+                            )
+                        }
+                    }
+                    !skill.error.isNullOrBlank() -> item("skill-error") {
+                        Text(skill.error, color = MaterialTheme.colorScheme.error)
+                    }
+                    else -> item("skill-empty") {
+                        Text(localizedString("This skill has no content."), color = PanelSecondaryText)
+                    }
                 }
                 if (skill.linkedFileNames.isNotEmpty()) {
-                    Spacer(Modifier.height(18.dp))
-                    PanelSectionLabel(localizedString("Linked Files"))
-                    skill.linkedFileNames.forEach { fileName ->
+                    item("skill-linked-header") {
+                        Spacer(Modifier.height(18.dp))
+                        PanelSectionLabel(localizedString("Linked Files"))
+                    }
+                    items(
+                        count = skill.linkedFileNames.size,
+                        key = { index -> "skill-linked-${skill.linkedFileNames[index]}-$index" },
+                    ) { index ->
+                        val fileName = skill.linkedFileNames[index]
                         LinkedFileRow(fileName, !isLoadingFile) { onOpenLinkedFile(fileName) }
                     }
                 }
-                Spacer(Modifier.height(18.dp))
             }
         }
     }
@@ -2084,8 +2132,11 @@ private fun MemoryEditSheet(
     onDismiss: () -> Unit,
     onSave: () -> Unit,
 ) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     ModalBottomSheet(
         onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        sheetGesturesEnabled = false,
         dragHandle = null,
         shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
         containerColor = Color.Transparent,
@@ -2093,11 +2144,13 @@ private fun MemoryEditSheet(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
+                .fillMaxHeight(0.9f)
                 .hermexGlass(
                     shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
                     castsShadow = false,
                     surfaceLevel = HermexSurfaceLevel.Floating,
                 )
+                .testTag("memory_edit_sheet")
                 .padding(horizontal = 16.dp, vertical = 14.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
@@ -2122,7 +2175,10 @@ private fun MemoryEditSheet(
                 onValueChange = onDraftChange,
                 minLines = 12,
                 maxLines = 18,
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+                    .testTag("memory_edit_body"),
                 enabled = !isSaving,
             )
             if (isSaving) {

--- a/android/app/src/main/java/com/uzairansar/hermex/ui/panels/PanelsViewModel.kt
+++ b/android/app/src/main/java/com/uzairansar/hermex/ui/panels/PanelsViewModel.kt
@@ -13,6 +13,7 @@ import com.uzairansar.hermex.core.model.MemoryResponse
 import com.uzairansar.hermex.core.model.SessionSummary
 import com.uzairansar.hermex.core.model.SkillContentResponse
 import com.uzairansar.hermex.core.model.SkillSummary
+import com.uzairansar.hermex.core.model.isConfirmedMutation
 import com.uzairansar.hermex.data.repository.PanelsRepository
 import com.uzairansar.hermex.core.network.HermesJson
 import com.uzairansar.hermex.ui.SavedStatePolicy
@@ -39,6 +40,7 @@ data class CronTaskDraft(
     val deliver: String = "local",
     val skillsText: String = "",
     val model: String = "",
+    val provider: String = "",
     val profile: String = "",
     val toastNotifications: Boolean = true,
 ) {
@@ -297,8 +299,7 @@ class PanelsViewModel(
                 !response.error.isNullOrBlank() -> response.error
                 response.ok == false && response.status == "already_running" ->
                     "Task is already running${response.elapsed?.let { " (${String.format(java.util.Locale.US, "%.1f", it)}s)" }.orEmpty()}."
-                response.ok == false -> "The server could not start this task."
-                else -> null
+                else -> response.mutationError("The server could not start this task.")
             }
         }
     }
@@ -378,6 +379,7 @@ class PanelsViewModel(
                     deliver = job.deliver ?: "local",
                     skillsText = job.skills.orEmpty().joinToString(", "),
                     model = job.model.orEmpty(),
+                    provider = job.provider.orEmpty(),
                     profile = job.profile.orEmpty(),
                     toastNotifications = job.toastNotifications ?: true,
             ),
@@ -418,6 +420,7 @@ class PanelsViewModel(
                         deliver = draft.deliver.trim().ifBlank { null },
                         skills = draft.skills,
                         model = draft.model.trim().ifBlank { null },
+                        provider = draft.provider.trim().ifBlank { null },
                         profile = draft.profile.trim().ifBlank { null },
                         toastNotifications = draft.toastNotifications,
                     ),
@@ -431,6 +434,7 @@ class PanelsViewModel(
                         deliver = draft.deliver.trim().ifBlank { null },
                         skills = draft.skills,
                         model = draft.model.trim().ifBlank { null },
+                        provider = draft.provider.trim().ifBlank { null },
                         profile = draft.profile.trim().ifBlank { null },
                         toastNotifications = draft.toastNotifications,
                     ),
@@ -578,7 +582,11 @@ class PanelsViewModel(
             }
             runSuspendCatching { repository.toggleSkill(name, enable) }
                 .onSuccess { response ->
-                    if (response.error == null && response.ok != false) {
+                    val confirmed = response.error.isNullOrBlank() && response.ok != false && (
+                        response.ok == true ||
+                            (response.name?.trim() == name && response.enabled == enable)
+                        )
+                    if (confirmed) {
                         _state.update {
                             it.copy(
                                 togglingSkillNames = it.togglingSkillNames - name,
@@ -650,7 +658,8 @@ class PanelsViewModel(
                 _state.update { it.copy(editingMemorySection = null) }
             },
         ) {
-            repository.writeMemory(section, content).error
+            val response = repository.writeMemory(section, content)
+            if (response.isConfirmedMutation()) null else response.error ?: "The server did not confirm the memory update."
         }
     }
 
@@ -709,6 +718,7 @@ private fun CronTaskDraft.boundedForPersistence(): CronTaskDraft = copy(
     deliver = SavedStatePolicy.boundedInput(deliver),
     skillsText = SavedStatePolicy.boundedInput(skillsText),
     model = SavedStatePolicy.boundedInput(model),
+    provider = SavedStatePolicy.boundedInput(provider),
     profile = SavedStatePolicy.boundedInput(profile),
 )
 
@@ -719,7 +729,7 @@ val CronJob.serverJobId: String?
     get() = jobId ?: id
 
 private fun com.uzairansar.hermex.core.model.CronMutationResponse.mutationError(fallback: String): String? =
-    error?.trim()?.takeIf { it.isNotBlank() } ?: fallback.takeIf { ok == false }
+    error?.trim()?.takeIf { it.isNotBlank() } ?: fallback.takeUnless { isConfirmedMutation() }
 
 val CronJob.displayName: String
     get() = name?.takeIf { it.isNotBlank() }

--- a/android/app/src/main/java/com/uzairansar/hermex/ui/sessions/SessionListViewModel.kt
+++ b/android/app/src/main/java/com/uzairansar/hermex/ui/sessions/SessionListViewModel.kt
@@ -15,6 +15,7 @@ import com.uzairansar.hermex.core.model.SessionExportFile
 import com.uzairansar.hermex.core.model.SessionExportFormat
 import com.uzairansar.hermex.core.model.SessionMutationResponse
 import com.uzairansar.hermex.core.model.SessionSummary
+import com.uzairansar.hermex.core.model.isConfirmedMutation
 import com.uzairansar.hermex.data.preferences.LocalSettingsRepository
 import com.uzairansar.hermex.data.preferences.SessionRowDisplaySettings
 import com.uzairansar.hermex.data.repository.PanelsRepository
@@ -823,10 +824,10 @@ class SessionListViewModel(
 private const val REMOTE_SEARCH_DEBOUNCE_MILLIS = 350L
 
 private fun SessionMutationResponse.mutationError(fallback: String): String? =
-    error?.trim()?.takeIf { it.isNotBlank() } ?: fallback.takeIf { ok == false }
+    error?.trim()?.takeIf { it.isNotBlank() } ?: fallback.takeUnless { isConfirmedMutation() }
 
 private fun ProjectMutationResponse.mutationError(fallback: String): String? =
-    error?.trim()?.takeIf { it.isNotBlank() } ?: fallback.takeIf { ok == false }
+    error?.trim()?.takeIf { it.isNotBlank() } ?: fallback.takeUnless { isConfirmedMutation() }
 
 private fun SessionBranchResponse.mutationError(): String? = error?.trim()?.takeIf { it.isNotBlank() }
 

--- a/android/app/src/main/java/com/uzairansar/hermex/ui/settings/SettingsRoute.kt
+++ b/android/app/src/main/java/com/uzairansar/hermex/ui/settings/SettingsRoute.kt
@@ -90,6 +90,7 @@ import androidx.core.content.ContextCompat
 import com.uzairansar.hermex.R
 import com.uzairansar.hermex.data.preferences.displayModelTitle
 import com.uzairansar.hermex.data.preferences.modelIdentifier
+import com.uzairansar.hermex.data.preferences.normalizedProvider
 import com.uzairansar.hermex.data.preferences.AppThemeMode
 import com.uzairansar.hermex.data.preferences.LocalSettingsRepository
 import com.uzairansar.hermex.data.preferences.StreamingSendBehavior
@@ -1502,7 +1503,8 @@ private fun DefaultModelPickerDialog(
                         group.models.forEach { model ->
                             DefaultModelOptionRow(
                                 model = model,
-                                selected = model.modelIdentifier == state.defaultModel,
+                                selected = model.modelIdentifier == state.defaultModel &&
+                                    (state.defaultModelProvider == null || model.normalizedProvider == state.defaultModelProvider),
                                 enabled = !state.isSavingDefaultModel,
                                 onClick = { onSaveModel(model) },
                             )
@@ -2075,7 +2077,11 @@ private fun Color.luminanceValue(): Float =
 
 private fun defaultModelLabel(state: SettingsUiState): String {
     val modelId = state.defaultModel?.trim()?.takeIf { it.isNotBlank() } ?: return "Server default"
-    return state.models.firstOrNull { it.modelIdentifier == modelId }?.displayModelTitle ?: modelId
+    val model = state.models.firstOrNull {
+        it.modelIdentifier == modelId &&
+            (state.defaultModelProvider == null || it.normalizedProvider == state.defaultModelProvider)
+    }
+    return model?.displayModelTitle ?: listOfNotNull(modelId, state.defaultModelProvider?.let { "($it)" }).joinToString(" ")
 }
 
 private fun defaultProfileLabel(state: SettingsUiState): String {

--- a/android/app/src/main/java/com/uzairansar/hermex/ui/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/uzairansar/hermex/ui/settings/SettingsViewModel.kt
@@ -14,11 +14,16 @@ import com.uzairansar.hermex.core.model.ProfilesResponse
 import com.uzairansar.hermex.core.model.ProviderSummary
 import com.uzairansar.hermex.core.model.SettingsResponse
 import com.uzairansar.hermex.core.model.UpdatesCheckResponse
+import com.uzairansar.hermex.core.model.isConfirmedDefaultModel
+import com.uzairansar.hermex.core.model.isConfirmedProfileSwitch
+import com.uzairansar.hermex.core.model.isConfirmedMutation
+import com.uzairansar.hermex.core.model.isConfirmedShowCliSessions
 import com.uzairansar.hermex.core.network.CustomHeader
 import com.uzairansar.hermex.core.network.parseCustomHeaderLines
 import com.uzairansar.hermex.data.repository.AddServerResult
 import com.uzairansar.hermex.data.repository.AuthState
 import com.uzairansar.hermex.data.preferences.modelIdentifier
+import com.uzairansar.hermex.data.preferences.normalizedProvider
 import com.uzairansar.hermex.data.preferences.AppThemeMode
 import com.uzairansar.hermex.data.preferences.ChatDisplaySettings
 import com.uzairansar.hermex.data.preferences.LocalSettingsRepository
@@ -84,6 +89,7 @@ data class SettingsUiState(
     val models: List<ModelSummary> = emptyList(),
     val modelProviders: List<ProviderSummary> = emptyList(),
     val defaultModel: String? = null,
+    val defaultModelProvider: String? = null,
     val profiles: List<ProfileSummary> = emptyList(),
     val activeProfile: String? = null,
     val isSingleProfileMode: Boolean = false,
@@ -440,7 +446,8 @@ class SettingsViewModel(
                     isLoadingServerSettings = false,
                     models = modelsResult.getOrNull()?.models.orEmpty(),
                     modelProviders = modelsResult.getOrNull()?.providers.orEmpty(),
-                    defaultModel = modelsResult.getOrNull()?.defaultModel,
+                    defaultModel = settings?.defaultModel ?: modelsResult.getOrNull()?.defaultModel,
+                    defaultModelProvider = settings?.defaultModelProvider ?: modelsResult.getOrNull()?.activeProvider,
                     profiles = profilesResult.getOrNull()?.profiles.orEmpty(),
                     activeProfile = profilesResult.getOrNull()?.effectiveDefaultProfileName(),
                     isSingleProfileMode = profilesResult.getOrNull()?.singleProfileMode == true,
@@ -485,6 +492,18 @@ class SettingsViewModel(
             runSuspendCatching { repository.updateSettings(showCliSessions = enabled) }
                 .onSuccess { response ->
                     if (generation != cliSessionsSaveGeneration) return@onSuccess
+                    if (!response.isConfirmedShowCliSessions(enabled)) {
+                        localSettingsRepository.setShowCliSessions(serverId, previous)
+                        _state.update {
+                            it.copy(
+                                showCliSessions = previous,
+                                isSavingCliSessions = false,
+                                cliSessionsError = "The server did not confirm the session visibility change.",
+                                error = "The server did not confirm the session visibility change.",
+                            )
+                        }
+                        return@onSuccess
+                    }
                     response.showCliSessions?.let { serverValue ->
                         localSettingsRepository.setShowCliSessions(serverId, serverValue)
                     }
@@ -1192,12 +1211,13 @@ class SettingsViewModel(
             runSuspendCatching { repository.switchProfile(name) }
                 .onSuccess { response ->
                     val responseError = response.error?.trim()?.takeIf { it.isNotBlank() }
-                    if (responseError != null) {
+                    if (responseError != null || !response.isConfirmedProfileSwitch(name)) {
+                        val message = responseError ?: "The server did not confirm the profile change."
                         _state.update {
                             it.copy(
                                 isSavingDefaultProfile = false,
-                                defaultProfilePickerError = responseError,
-                                error = responseError,
+                                defaultProfilePickerError = message,
+                                error = message,
                             )
                         }
                         return@onSuccess
@@ -1213,6 +1233,7 @@ class SettingsViewModel(
                             profiles = profiles,
                             activeProfile = resolved,
                             defaultModel = response.defaultModel ?: it.defaultModel,
+                            defaultModelProvider = response.defaultModelProvider ?: it.defaultModelProvider,
                             notice = "Default profile saved.",
                             defaultProfilePickerError = null,
                             error = null,
@@ -1227,19 +1248,23 @@ class SettingsViewModel(
     }
 
     fun saveDefaultModel(model: ModelSummary) {
-        saveDefaultModelId(model.modelIdentifier.orEmpty())
+        saveDefaultModelId(model.modelIdentifier.orEmpty(), model.normalizedProvider)
     }
 
     fun saveDefaultModelId(rawModelId: String) {
+        saveDefaultModelId(rawModelId, providerId = null)
+    }
+
+    private fun saveDefaultModelId(rawModelId: String, providerId: String?) {
         val repository = panelsRepository ?: return
         val id = rawModelId.trim()
         if (id.isBlank()) return
         viewModelScope.launch {
             _state.update { it.copy(isSavingDefaultModel = true, error = null, notice = null) }
-            runSuspendCatching { repository.saveDefaultModel(id) }
+            runSuspendCatching { repository.saveDefaultModel(id, providerId) }
                 .onSuccess { response ->
                     val responseError = response.error?.trim()?.takeIf { it.isNotBlank() }
-                    if (responseError != null || response.ok == false) {
+                    if (responseError != null || !response.isConfirmedDefaultModel(providerId)) {
                         val message = responseError ?: "The server did not confirm the change."
                         _state.update {
                             it.copy(
@@ -1255,6 +1280,7 @@ class SettingsViewModel(
                             isSavingDefaultModel = false,
                             showDefaultModelPicker = false,
                             defaultModel = response.model ?: id,
+                            defaultModelProvider = response.provider ?: providerId,
                             notice = "Default model saved.",
                             defaultModelPickerError = null,
                             error = null,
@@ -1354,12 +1380,13 @@ class SettingsViewModel(
             }
                 .onSuccess { response ->
                     val responseError = response.error?.trim()?.takeIf { it.isNotBlank() }
-                    if (responseError != null) {
+                    if (responseError != null || !response.isConfirmedMutation()) {
+                        val message = responseError ?: "The server did not confirm profile creation."
                         _state.update {
                             it.copy(
                                 isCreatingProfile = false,
-                                profileCreateError = responseError,
-                                error = responseError,
+                                profileCreateError = message,
+                                error = message,
                             )
                         }
                         return@onSuccess

--- a/android/app/src/main/java/com/uzairansar/hermex/ui/workspace/WorkspaceRoute.kt
+++ b/android/app/src/main/java/com/uzairansar/hermex/ui/workspace/WorkspaceRoute.kt
@@ -701,6 +701,7 @@ private fun saveWorkspaceImageToGallery(
 ): String {
     val resolver = context.contentResolver
     val fileName = preview.galleryFileName()
+    val bytes = preview.bytes ?: return "This image is not loaded."
     val values = ContentValues().apply {
         put(MediaStore.MediaColumns.DISPLAY_NAME, fileName)
         put(MediaStore.MediaColumns.MIME_TYPE, preview.mimeType)
@@ -714,7 +715,6 @@ private fun saveWorkspaceImageToGallery(
     }.getOrNull() ?: return "Could not save image."
 
     return try {
-        val bytes = preview.bytes ?: return "This image is not loaded."
         resolver.openOutputStream(uri)?.use { output -> output.write(bytes) }
             ?: error("Could not open gallery item.")
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {

--- a/android/app/src/main/res/xml/backup_rules.xml
+++ b/android/app/src/main/res/xml/backup_rules.xml
@@ -1,5 +1,6 @@
 <full-backup-content>
     <exclude domain="sharedpref" path="hermex_secure.xml" />
+    <exclude domain="sharedpref" path="hermex_secure_v2.xml" />
     <exclude domain="sharedpref" path="hermex_share.xml" />
     <exclude domain="sharedpref" path="hermex_chat_pending_state.xml" />
     <exclude domain="sharedpref" path="hermex_stream_recovery.xml" />

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,12 +1,14 @@
 <data-extraction-rules>
     <cloud-backup>
         <exclude domain="sharedpref" path="hermex_secure.xml" />
+        <exclude domain="sharedpref" path="hermex_secure_v2.xml" />
         <exclude domain="sharedpref" path="hermex_share.xml" />
         <exclude domain="sharedpref" path="hermex_chat_pending_state.xml" />
         <exclude domain="sharedpref" path="hermex_stream_recovery.xml" />
     </cloud-backup>
     <device-transfer>
         <exclude domain="sharedpref" path="hermex_secure.xml" />
+        <exclude domain="sharedpref" path="hermex_secure_v2.xml" />
         <exclude domain="sharedpref" path="hermex_share.xml" />
         <exclude domain="sharedpref" path="hermex_chat_pending_state.xml" />
         <exclude domain="sharedpref" path="hermex_stream_recovery.xml" />

--- a/android/app/src/test/java/com/uzairansar/hermex/core/model/MutationConfirmationTest.kt
+++ b/android/app/src/test/java/com/uzairansar/hermex/core/model/MutationConfirmationTest.kt
@@ -1,0 +1,65 @@
+package com.uzairansar.hermex.core.model
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MutationConfirmationTest {
+    @Test
+    fun emptyResponsesNeverConfirmMutations() {
+        assertFalse(SessionMutationResponse().isConfirmedMutation())
+        assertFalse(SessionClearResponse().isConfirmedMutation())
+        assertFalse(SessionCompressResponse().isConfirmedMutation())
+        assertFalse(SessionUndoResponse().isConfirmedMutation())
+        assertFalse(SessionRetryResponse().isConfirmedMutation())
+        assertFalse(ProjectMutationResponse().isConfirmedMutation())
+        assertFalse(CronMutationResponse().isConfirmedMutation())
+        assertFalse(ChatCancelResponse().isConfirmedMutation())
+        assertFalse(GoalSubmissionResponse().isConfirmedMutation())
+        assertFalse(PersonalitySetResponse().isConfirmedPersonalityMutation("focused"))
+        assertFalse(ApprovalRespondResponse().isConfirmedMutation())
+        assertFalse(SessionYoloResponse().isConfirmedYoloMutation(enabled = true))
+        assertFalse(ClarificationRespondResponse().isConfirmedClarification("answer"))
+        assertFalse(DefaultModelResponse().isConfirmedDefaultModel("openai-codex"))
+        assertFalse(ProfileSwitchResponse().isConfirmedProfileSwitch("review"))
+        assertFalse(ProfileCreateResponse().isConfirmedMutation())
+        assertFalse(MemoryWriteResponse().isConfirmedMutation())
+        assertFalse(SettingsResponse().isConfirmedShowCliSessions(enabled = true))
+    }
+
+    @Test
+    fun requiredPayloadsConfirmLegacyResponsesWithoutOk() {
+        assertTrue(SessionMutationResponse(session = SessionSummary(sessionId = "s1")).isConfirmedMutation())
+        assertTrue(SessionClearResponse(session = SessionDetail(sessionId = "s1")).isConfirmedMutation())
+        assertTrue(SessionCompressResponse(session = SessionDetail(sessionId = "s1")).isConfirmedMutation())
+        assertTrue(ProjectMutationResponse(project = ProjectSummary(projectId = "p1")).isConfirmedMutation())
+        assertTrue(CronMutationResponse(jobId = "job-1").isConfirmedMutation())
+    }
+
+    @Test
+    fun explicitSuccessConfirmsAndErrorsAlwaysReject() {
+        assertTrue(SessionMutationResponse(ok = true).isConfirmedMutation())
+        assertTrue(SessionUndoResponse(ok = true).isConfirmedMutation())
+        assertTrue(SessionRetryResponse(ok = true).isConfirmedMutation())
+        assertFalse(SessionMutationResponse(ok = true, error = "failed").isConfirmedMutation())
+        assertTrue(ChatCancelResponse(ok = true, cancelled = true).isConfirmedMutation())
+        assertTrue(GoalSubmissionResponse(ok = true, action = "set").isConfirmedMutation())
+        assertTrue(PersonalitySetResponse(ok = true, personality = "focused").isConfirmedPersonalityMutation("focused"))
+        assertTrue(PersonalitySetResponse(ok = true).isConfirmedPersonalityMutation(""))
+        assertTrue(ApprovalRespondResponse(ok = true).isConfirmedMutation())
+        assertTrue(ApprovalRespondResponse(staleCleared = true).isConfirmedMutation())
+        assertTrue(SessionYoloResponse(ok = true, yoloEnabled = true).isConfirmedYoloMutation(enabled = true))
+        assertTrue(ClarificationRespondResponse(ok = true, response = "answer").isConfirmedClarification("answer"))
+        assertTrue(DefaultModelResponse(ok = true, model = "gpt-5", provider = "openai-codex").isConfirmedDefaultModel("openai-codex"))
+        assertTrue(ProfileSwitchResponse(active = "review").isConfirmedProfileSwitch("review"))
+        assertTrue(ProfileCreateResponse(ok = true).isConfirmedMutation())
+        assertTrue(MemoryWriteResponse(ok = true).isConfirmedMutation())
+        assertTrue(SettingsResponse(showCliSessions = true).isConfirmedShowCliSessions(enabled = true))
+
+        assertFalse(PersonalitySetResponse(ok = true, personality = "other").isConfirmedPersonalityMutation("focused"))
+        assertFalse(SessionYoloResponse(ok = true, yoloEnabled = false).isConfirmedYoloMutation(enabled = true))
+        assertFalse(ClarificationRespondResponse(ok = true, response = "different").isConfirmedClarification("answer"))
+        assertFalse(DefaultModelResponse(ok = true, model = "gpt-5", provider = "openai").isConfirmedDefaultModel("openai-codex"))
+        assertFalse(ProfileSwitchResponse(active = "default").isConfirmedProfileSwitch("review"))
+    }
+}

--- a/android/app/src/test/java/com/uzairansar/hermex/core/network/HermesApiClientSafetyTest.kt
+++ b/android/app/src/test/java/com/uzairansar/hermex/core/network/HermesApiClientSafetyTest.kt
@@ -116,10 +116,11 @@ class HermesApiClientSafetyTest {
                     .build(),
             )
             HermesApiClient(server.url("/"), OkHttpClient()).updateCron(
-                CronUpdateRequest(jobId = "job-1", model = null, profile = null),
+                CronUpdateRequest(jobId = "job-1", model = null, provider = null, profile = null),
             )
             val body = server.takeRequest().body?.utf8().orEmpty()
             assertTrue(body.contains("\"model\":null"))
+            assertTrue(body.contains("\"provider\":null"))
             assertTrue(body.contains("\"profile\":null"))
         } finally {
             server.close()

--- a/android/app/src/test/java/com/uzairansar/hermex/core/network/HermesApiClientSessionTest.kt
+++ b/android/app/src/test/java/com/uzairansar/hermex/core/network/HermesApiClientSessionTest.kt
@@ -417,7 +417,7 @@ class HermesApiClientSessionTest {
                 MockResponse.Builder()
                     .code(200)
                     .addHeader("Content-Type", "application/json")
-                    .body("""{"active":"work","default_model":"gpt-5.5","default_workspace":"/workspace","profiles":[{"name":"work","is_active":true}]}""")
+                    .body("""{"active":"work","default_model":"gpt-5.5","default_model_provider":"openai-codex","default_workspace":"/workspace","profiles":[{"name":"work","is_active":true}]}""")
                     .build(),
             )
 
@@ -427,6 +427,7 @@ class HermesApiClientSessionTest {
             val request = server.takeRequest()
             assertEquals("work", response.active)
             assertEquals("gpt-5.5", response.defaultModel)
+            assertEquals("openai-codex", response.defaultModelProvider)
             assertEquals("/workspace", response.defaultWorkspace)
             assertEquals(true, response.profiles?.single()?.isActive)
             assertEquals("/api/profile/switch", request.url.encodedPath)

--- a/android/app/src/test/java/com/uzairansar/hermex/core/network/PendingPromptContractTest.kt
+++ b/android/app/src/test/java/com/uzairansar/hermex/core/network/PendingPromptContractTest.kt
@@ -8,6 +8,7 @@ import com.uzairansar.hermex.core.model.CompressSessionRequest
 import com.uzairansar.hermex.core.model.CronCreateRequest
 import com.uzairansar.hermex.core.model.CronJobIdRequest
 import com.uzairansar.hermex.core.model.CronUpdateRequest
+import com.uzairansar.hermex.core.model.DefaultModelRequest
 import com.uzairansar.hermex.core.model.GitCheckoutRequest
 import com.uzairansar.hermex.core.model.GoalRequest
 import com.uzairansar.hermex.core.model.MemoryWriteRequest
@@ -114,6 +115,7 @@ class PendingPromptContractTest {
                 deliver = "local",
                 skills = listOf("summarizer", "calendar"),
                 model = "gpt-5",
+                provider = "openai-codex",
                 profile = "default",
                 toastNotifications = true,
             ),
@@ -124,6 +126,7 @@ class PendingPromptContractTest {
         assertTrue(body.contains(""""name":"Morning summary""""))
         assertTrue(body.contains(""""deliver":"local""""))
         assertTrue(body.contains(""""skills":["summarizer","calendar"]"""))
+        assertTrue(body.contains(""""provider":"openai-codex"""))
         assertTrue(body.contains(""""toast_notifications":true"""))
     }
 
@@ -136,6 +139,7 @@ class PendingPromptContractTest {
                 schedule = "@daily",
                 name = null,
                 skills = emptyList(),
+                provider = "openai-codex",
                 toastNotifications = false,
             ),
         )
@@ -144,8 +148,17 @@ class PendingPromptContractTest {
         assertTrue(body.contains(""""prompt":"Updated prompt.""""))
         assertTrue(body.contains(""""schedule":"@daily""""))
         assertTrue(body.contains(""""skills":[]"""))
+        assertTrue(body.contains(""""provider":"openai-codex"""))
         assertTrue(body.contains(""""toast_notifications":false"""))
         assertFalse(body.contains(""""name""""))
+    }
+
+    @Test
+    fun defaultModelRequestPreservesProviderIdentity() {
+        val body = HermesJson.encodeToString(DefaultModelRequest(model = "gpt-5", provider = "openai-codex"))
+
+        assertTrue(body.contains(""""model":"gpt-5"""))
+        assertTrue(body.contains(""""provider":"openai-codex"""))
     }
 
     @Test

--- a/android/app/src/test/java/com/uzairansar/hermex/core/network/PersistentCookieJarTest.kt
+++ b/android/app/src/test/java/com/uzairansar/hermex/core/network/PersistentCookieJarTest.kt
@@ -71,6 +71,21 @@ class PersistentCookieJarTest {
 
         assertTrue(jar.loadForRequest(url).isEmpty())
     }
+
+    @Test
+    fun clearingParentServerPreservesHostOnlySubdomainCookie() {
+        val jar = PersistentCookieJar(ConcurrentSecretStore())
+        val parentUrl = "https://example.test/".toHttpUrl()
+        val childUrl = "https://hermes.example.test/".toHttpUrl()
+        jar.saveFromResponse(
+            childUrl,
+            listOf(Cookie.Builder().name("child-session").value("token").hostOnlyDomain(childUrl.host).path("/").build()),
+        )
+
+        jar.clear(parentUrl)
+
+        assertEquals("child-session", jar.loadForRequest(childUrl).single().name)
+    }
 }
 
 private class ConcurrentSecretStore : SecretStore {

--- a/android/app/src/test/java/com/uzairansar/hermex/core/network/SseEventDecoderTest.kt
+++ b/android/app/src/test/java/com/uzairansar/hermex/core/network/SseEventDecoderTest.kt
@@ -66,6 +66,51 @@ class SseEventDecoderTest {
     }
 
     @Test
+    fun preservesAuthoritativeSessionAndContinuationFromAppError() {
+        val event = SseEventDecoder.decode(
+            "apperror",
+            """
+            {
+              "message":"Provider failed",
+              "hint":"Choose another model",
+              "details":"HTTP 401",
+              "session_id":"session-old",
+              "continuation_session_id":"session-new",
+              "session":{
+                "session_id":"session-new",
+                "messages":[{"role":"assistant","content":"Saved failure","message_id":"error-1"}]
+              }
+            }
+            """.trimIndent(),
+        )
+
+        assertTrue(event is SseEvent.Error)
+        event as SseEvent.Error
+        assertEquals("Provider failed", event.message)
+        assertEquals("Choose another model", event.hint)
+        assertEquals("HTTP 401", event.details)
+        assertEquals("session-old", event.sessionId)
+        assertEquals("session-new", event.replacementSessionId)
+        assertEquals("Saved failure", event.session?.messages?.single()?.content)
+    }
+
+    @Test
+    fun preservesSessionFromCancelFrame() {
+        val event = SseEventDecoder.decode(
+            "cancel",
+            """{"session":{"session_id":"session-1","messages":[]}}""",
+        )
+
+        assertEquals(
+            SseEvent.Cancelled(
+                session = com.uzairansar.hermex.core.model.SessionDetail(sessionId = "session-1", messages = emptyList()),
+                sessionId = "session-1",
+            ),
+            event,
+        )
+    }
+
+    @Test
     fun decodesApprovalAndClarificationFrames() {
         val approval = SseEventDecoder.decode(
             "approval",

--- a/android/app/src/test/java/com/uzairansar/hermex/core/network/SseStreamClientIntegrationTest.kt
+++ b/android/app/src/test/java/com/uzairansar/hermex/core/network/SseStreamClientIntegrationTest.kt
@@ -13,6 +13,50 @@ import org.junit.Test
 
 class SseStreamClientIntegrationTest {
     @Test
+    fun continuesDeliveringMetadataUntilStreamEndAfterDone() = runBlocking {
+        val server = MockWebServer()
+        try {
+            server.start()
+            server.enqueue(
+                MockResponse.Builder()
+                    .code(200)
+                    .addHeader("Content-Type", "text/event-stream")
+                    .body(
+                        """
+                        event: done
+                        data: {"session_id":"s1"}
+
+                        event: title
+                        data: {"session_id":"s1","title":"Post-done title"}
+
+                        event: stream_end
+                        data: {}
+
+                        """.trimIndent(),
+                    )
+                    .build(),
+            )
+
+            val events = withTimeout(5_000) {
+                SseStreamClient(server.url("/"), OkHttpClient()) { emptyList() }
+                    .stream(server.url("/api/chat/stream?stream_id=stream-1"))
+                    .toList()
+            }
+
+            assertEquals(
+                listOf(
+                    SseEvent.Done(sessionId = "s1", usage = null, session = null),
+                    SseEvent.Title(sessionId = "s1", title = "Post-done title"),
+                    SseEvent.StreamEnd,
+                ),
+                events,
+            )
+        } finally {
+            server.close()
+        }
+    }
+
+    @Test
     fun deliversEventsAndClassifiesNormalActiveStreamCloseAsRecoverable() = runBlocking {
         val server = MockWebServer()
         try {

--- a/android/app/src/test/java/com/uzairansar/hermex/ui/chat/ChatStateSafetyPolicyTest.kt
+++ b/android/app/src/test/java/com/uzairansar/hermex/ui/chat/ChatStateSafetyPolicyTest.kt
@@ -54,6 +54,15 @@ class ChatStateSafetyPolicyTest {
     }
 
     @Test
+    fun draftPersistenceKeepsNormalDraftsAndRejectsOversizedPayloads() {
+        assertEquals("hello", ChatDraftPersistencePolicy.persistedDraft("hello"))
+        assertEquals(
+            "",
+            ChatDraftPersistencePolicy.persistedDraft("x".repeat(ChatDraftPersistencePolicy.MaximumPersistedCharacters + 1)),
+        )
+    }
+
+    @Test
     fun pendingChatStateRoundTripsAcrossProcessRecreation() {
         val state = PersistedChatPendingState(
             draft = "unsent draft",

--- a/android/app/src/test/java/com/uzairansar/hermex/ui/chat/ChatStreamRecoveryPolicyTest.kt
+++ b/android/app/src/test/java/com/uzairansar/hermex/ui/chat/ChatStreamRecoveryPolicyTest.kt
@@ -26,6 +26,13 @@ class ChatStreamRecoveryPolicyTest {
     }
 
     @Test
+    fun serviceStopsOnlyWhenJobsAndDurableRecordsAreBothEmpty() {
+        assertTrue(streamRecoveryShouldStop(activeJobCount = 0, durableRecordCount = 0))
+        assertFalse(streamRecoveryShouldStop(activeJobCount = 1, durableRecordCount = 0))
+        assertFalse(streamRecoveryShouldStop(activeJobCount = 0, durableRecordCount = 1))
+    }
+
+    @Test
     fun recoversWhenActiveStreamFlowClosesWithoutCause() {
         assertTrue(
             ChatStreamRecoveryPolicy.shouldRecoverAfterFlowCompletion(

--- a/android/app/src/test/java/com/uzairansar/hermex/ui/git/GitResponsePolicyTest.kt
+++ b/android/app/src/test/java/com/uzairansar/hermex/ui/git/GitResponsePolicyTest.kt
@@ -18,10 +18,14 @@ class GitResponsePolicyTest {
     }
 
     @Test
-    fun serverErrorTakesPriorityAndSuccessfulOrLegacyResponsesPass() {
+    fun serverErrorTakesPriorityAndAffirmativeLegacyResponsesPass() {
         assertEquals("server reason", GitMutationResponse(ok = false, error = " server reason ").failureMessage("fallback"))
         assertNull(GitMutationResponse(ok = true).failureMessage("fallback"))
-        assertNull(GitMutationResponse(ok = null).failureMessage("fallback"))
+        assertNull(GitMutationResponse(message = "Fetched").failureMessage("fallback"))
+        assertEquals("fallback", GitMutationResponse().failureMessage("fallback"))
+        assertEquals("fallback", GitCommitResponse().failureMessage("fallback"))
+        assertEquals("fallback", GitCommitMessageResponse().failureMessage("fallback"))
+        assertEquals("fallback", GitCheckoutResponse().failureMessage("fallback"))
     }
 
     @Test


### PR DESCRIPTION
## What changed

- fixes Android skill-detail crashes and scrollable modal instability
- hardens streaming, mutation confirmation, provider persistence, storage, cookies, and recovery behavior
- expands Android CI and release validation
- publishes Android 1.0.5 and makes README release links version-independent

## Why

The Android audit found lifecycle, rendering, API-contract, persistence, and release-gating defects that could cause crashes, stale state, false success messages, or inconsistent behavior.

## Validation

- full JVM unit suite
- 41/41 API 35 managed-device tests
- debug and release lint
- endpoint and localization parity
- signed APK and AAB release workflow