### PR TITLE
fix(android): show tool names for nested function tool calls

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         applicationId = "com.uzairansar.hermex"
         minSdk = 26
         targetSdk = 36
-        versionCode = 32
-        versionName = "1.1.2"
+        versionCode = 33
+        versionName = "1.1.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/android/app/src/main/java/com/uzairansar/hermex/core/model/Dto.kt
+++ b/android/app/src/main/java/com/uzairansar/hermex/core/model/Dto.kt
@@ -847,15 +847,172 @@ object MessageAttachmentSerializer : KSerializer<MessageAttachment> {
     }
 }
 
-@Serializable
+@Serializable(with = ToolCallFunctionSerializer::class)
+data class ToolCallFunction(
+    val name: String? = null,
+    val arguments: String? = null,
+)
+
+object ToolCallFunctionSerializer : KSerializer<ToolCallFunction> {
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("ToolCallFunction") {
+        element<String?>("name")
+        element<String?>("arguments")
+    }
+
+    override fun deserialize(decoder: Decoder): ToolCallFunction {
+        val jsonDecoder = decoder as? JsonDecoder ?: return ToolCallFunction()
+        val element = jsonDecoder.decodeJsonElement() as? JsonObject ?: return ToolCallFunction()
+        val name = element["name"].stringOrNull()
+        val argumentsRaw = element["arguments"] ?: element["args"]
+        val argumentsString = when (argumentsRaw) {
+            is JsonPrimitive -> argumentsRaw.contentOrNull
+            is JsonObject, is JsonArray -> argumentsRaw.toString()
+            else -> null
+        }
+        return ToolCallFunction(
+            name = name,
+            arguments = argumentsString,
+        )
+    }
+
+    override fun serialize(encoder: Encoder, value: ToolCallFunction) {
+        val jsonEncoder = encoder as? JsonEncoder ?: return
+        jsonEncoder.encodeJsonElement(
+            buildJsonObject {
+                value.name?.let { put("name", it) }
+                value.arguments?.let { put("arguments", it) }
+            },
+        )
+    }
+}
+
+@Serializable(with = ToolCallSerializer::class)
 data class ToolCall(
     val id: String? = null,
+    val type: String? = null,
+    val function: ToolCallFunction? = null,
     val name: String? = null,
     val preview: String? = null,
     val args: Map<String, JsonElement>? = null,
     val result: JsonElement? = null,
     @SerialName("is_error") val isError: Boolean? = null,
-)
+) {
+    val displayName: String
+        get() = name?.trim()?.takeIf { it.isNotBlank() }
+            ?: function?.name?.trim()?.takeIf { it.isNotBlank() }
+            ?: preview?.lineSequence()?.firstOrNull { it.isNotBlank() }?.take(48)
+            ?: id?.trim()?.takeIf { it.isNotBlank() }
+            ?: "Tool"
+}
+
+object ToolCallSerializer : KSerializer<ToolCall> {
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("ToolCall") {
+        element<String?>("id")
+        element<String?>("type")
+        element<ToolCallFunction?>("function")
+        element<String?>("name")
+        element<String?>("preview")
+        element<Map<String, JsonElement>?>("args")
+        element<JsonElement?>("result")
+        element<Boolean?>("isError")
+    }
+
+    override fun deserialize(decoder: Decoder): ToolCall {
+        val jsonDecoder = decoder as? JsonDecoder ?: return ToolCall()
+        val element = jsonDecoder.decodeJsonElement() as? JsonObject ?: return ToolCall()
+
+        val id = element["id"].stringOrNull()
+            ?: element["call_id"].stringOrNull()
+            ?: element["tool_call_id"].stringOrNull()
+            ?: element["tid"].stringOrNull()
+
+        val type = element["type"].stringOrNull()
+
+        val functionElement = element["function"]
+        val function = when (functionElement) {
+            is JsonObject -> {
+                val fnName = functionElement["name"].stringOrNull()
+                val fnArgsRaw = functionElement["arguments"] ?: functionElement["args"]
+                val fnArgsString = when (fnArgsRaw) {
+                    is JsonPrimitive -> fnArgsRaw.contentOrNull
+                    is JsonObject, is JsonArray -> fnArgsRaw.toString()
+                    else -> null
+                }
+                ToolCallFunction(name = fnName, arguments = fnArgsString)
+            }
+            else -> null
+        }
+
+        val name = element["name"].stringOrNull()
+
+        val preview = element["preview"].stringOrNull()
+            ?: element["snippet"].stringOrNull()
+
+        val topLevelArgs = element["args"]
+            ?: element["arguments"]
+            ?: element["input"]
+        val functionArgs = (functionElement as? JsonObject)?.let { it["arguments"] ?: it["args"] }
+
+        val args = parseArgs(topLevelArgs, functionArgs, jsonDecoder)
+
+        val result = element["result"] ?: element["output"]
+
+        val isError = element["is_error"].booleanValueOrNull()
+            ?: element["isError"].booleanValueOrNull()
+
+        return ToolCall(
+            id = id,
+            type = type,
+            function = function,
+            name = name,
+            preview = preview,
+            args = args,
+            result = result,
+            isError = isError,
+        )
+    }
+
+    override fun serialize(encoder: Encoder, value: ToolCall) {
+        val jsonEncoder = encoder as? JsonEncoder ?: return
+        jsonEncoder.encodeJsonElement(
+            buildJsonObject {
+                value.id?.let { put("id", it) }
+                value.type?.let { put("type", it) }
+                value.function?.let { put("function", jsonEncoder.json.encodeToJsonElement(it)) }
+                value.name?.let { put("name", it) }
+                value.preview?.let { put("preview", it) }
+                value.args?.let { put("args", jsonEncoder.json.encodeToJsonElement(it)) }
+                value.result?.let { put("result", it) }
+                value.isError?.let { put("is_error", it) }
+            },
+        )
+    }
+
+    private fun parseArgs(
+        topLevelArgsElement: JsonElement?,
+        functionArgsElement: JsonElement?,
+        jsonDecoder: JsonDecoder,
+    ): Map<String, JsonElement>? {
+        val fromTopLevel = parseJsonElementToMap(topLevelArgsElement, jsonDecoder)
+        if (fromTopLevel != null) return fromTopLevel
+        return parseJsonElementToMap(functionArgsElement, jsonDecoder)
+    }
+
+    private fun parseJsonElementToMap(element: JsonElement?, jsonDecoder: JsonDecoder): Map<String, JsonElement>? {
+        return when (element) {
+            is JsonObject -> element.toMap()
+            is JsonPrimitive -> {
+                val text = element.contentOrNull?.trim()
+                if (text.isNullOrEmpty()) return null
+                runCatching {
+                    val parsed = jsonDecoder.json.parseToJsonElement(text)
+                    (parsed as? JsonObject)?.toMap()
+                }.getOrNull()
+            }
+            else -> null
+        }
+    }
+}
 
 @Serializable
 data class PersistedToolCall(
@@ -864,16 +1021,25 @@ data class PersistedToolCall(
     val tid: String? = null,
     @SerialName("assistant_msg_idx") val assistantMsgIdx: Int? = null,
     val args: Map<String, JsonElement>? = null,
+    val id: String? = null,
+    val type: String? = null,
+    val function: ToolCallFunction? = null,
 ) {
-    fun toToolCall(fallbackIndex: Int): ToolCall =
-        ToolCall(
-            id = tid?.trim()?.takeIf { it.isNotEmpty() } ?: "persisted-tool-$fallbackIndex",
+    fun toToolCall(fallbackIndex: Int): ToolCall {
+        val resolvedId = tid?.trim()?.takeIf { it.isNotEmpty() }
+            ?: id?.trim()?.takeIf { it.isNotEmpty() }
+            ?: "persisted-tool-$fallbackIndex"
+        return ToolCall(
+            id = resolvedId,
+            type = type,
+            function = function,
             name = name,
             preview = snippet,
             args = args,
             result = null,
             isError = null,
         )
+    }
 }
 
 data class ToolCallGroup(
@@ -936,7 +1102,7 @@ object ToolCallGroupResolver {
         val seen = linkedMapOf<String, ToolCall>()
         tools.forEachIndexed { index, tool ->
             val key = tool.id?.takeUnless { it.startsWith("persisted-tool-") }
-                ?: "${tool.name.orEmpty().trim()}:${tool.args?.toString().orEmpty()}:$index"
+                ?: "${tool.displayName.trim()}:${tool.args?.toString().orEmpty()}:$index"
             seen[key] = tool
         }
         return seen.values.toList()
@@ -1798,6 +1964,15 @@ private fun JsonElement?.doubleValueOrNull(): Double? {
 private fun JsonElement?.intValueOrNull(): Int? {
     val primitive = this as? JsonPrimitive ?: return null
     return primitive.intOrNull ?: primitive.contentOrNull?.trim()?.toIntOrNull()
+}
+
+private fun JsonElement?.booleanValueOrNull(): Boolean? {
+    val primitive = this as? JsonPrimitive ?: return null
+    return primitive.booleanOrNull ?: when (primitive.contentOrNull?.trim()?.lowercase()) {
+        "true", "1", "yes", "on" -> true
+        "false", "0", "no", "off" -> false
+        else -> null
+    }
 }
 
 @Serializable

--- a/android/app/src/main/java/com/uzairansar/hermex/core/model/TurnFileChangeSummary.kt
+++ b/android/app/src/main/java/com/uzairansar/hermex/core/model/TurnFileChangeSummary.kt
@@ -100,7 +100,10 @@ object TurnFileChangeAggregator {
     }
 
     private fun candidates(tool: ToolCall): List<PathCandidate> {
-        val name = tool.name?.trim()?.lowercase()?.takeIf { it.isNotBlank() } ?: return emptyList()
+        val name = (tool.name?.takeIf { it.isNotBlank() } ?: tool.function?.name)
+            ?.trim()
+            ?.lowercase()
+            ?.takeIf { it.isNotBlank() } ?: return emptyList()
         val action = actionForTool(name) ?: return emptyList()
         val args = tool.args.orEmpty()
 

--- a/android/app/src/main/java/com/uzairansar/hermex/ui/chat/ChatRoute.kt
+++ b/android/app/src/main/java/com/uzairansar/hermex/ui/chat/ChatRoute.kt
@@ -5716,11 +5716,6 @@ private fun ToolDetailSection(
     }
 }
 
-private val ToolCall.displayName: String
-    get() = name?.takeIf { it.isNotBlank() }
-        ?: preview?.lineSequence()?.firstOrNull { it.isNotBlank() }?.take(48)
-        ?: id?.takeIf { it.isNotBlank() }
-        ?: "Tool"
 
 private val ToolCall.collapsedStatusText: String?
     get() = when {

--- a/android/app/src/test/java/com/uzairansar/hermex/core/model/ToolCallDecodingTest.kt
+++ b/android/app/src/test/java/com/uzairansar/hermex/core/model/ToolCallDecodingTest.kt
@@ -1,0 +1,290 @@
+package com.uzairansar.hermex.core.model
+
+import com.uzairansar.hermex.core.network.HermesJson
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ToolCallDecodingTest {
+
+    @Test
+    fun decodesOpenAiStandardNestedFunctionEnvelope() {
+        val json = """
+            {
+              "id": "call_abc12345",
+              "type": "function",
+              "function": {
+                "name": "run_shell_command",
+                "arguments": "{\"command\":\"git status -s\",\"timeout\":30}"
+              }
+            }
+        """.trimIndent()
+
+        val toolCall = HermesJson.decodeFromString<ToolCall>(json)
+
+        assertEquals("call_abc12345", toolCall.id)
+        assertEquals("function", toolCall.type)
+        assertNotNull(toolCall.function)
+        assertEquals("run_shell_command", toolCall.function?.name)
+        assertEquals("{\"command\":\"git status -s\",\"timeout\":30}", toolCall.function?.arguments)
+        assertNull(toolCall.name)
+        assertEquals("run_shell_command", toolCall.displayName)
+
+        // Parsed structured arguments
+        assertNotNull(toolCall.args)
+        assertEquals(JsonPrimitive("git status -s"), toolCall.args?.get("command"))
+        assertEquals(JsonPrimitive(30), toolCall.args?.get("timeout"))
+    }
+
+    @Test
+    fun preservesCompatibilityWithHermesInternalShape() {
+        val json = """
+            {
+              "id": "tool-1",
+              "name": "edit_file",
+              "preview": "Replaced lines 10-20 in Dto.kt",
+              "args": {
+                "path": "Dto.kt",
+                "replace": true
+              },
+              "result": "Success",
+              "is_error": false
+            }
+        """.trimIndent()
+
+        val toolCall = HermesJson.decodeFromString<ToolCall>(json)
+
+        assertEquals("tool-1", toolCall.id)
+        assertEquals("edit_file", toolCall.name)
+        assertEquals("Replaced lines 10-20 in Dto.kt", toolCall.preview)
+        assertEquals("edit_file", toolCall.displayName)
+        assertNotNull(toolCall.args)
+        assertEquals(JsonPrimitive("Dto.kt"), toolCall.args?.get("path"))
+        assertEquals(JsonPrimitive(true), toolCall.args?.get("replace"))
+        assertEquals(JsonPrimitive("Success"), toolCall.result)
+        assertEquals(false, toolCall.isError)
+    }
+
+    @Test
+    fun displayNameFollowsPrecedenceHierarchy() {
+        // 1. Top-level Hermes name remains authoritative when both shapes are present
+        val nestedWithTopLevel = HermesJson.decodeFromString<ToolCall>(
+            """{"id":"call_1","name":"legacy_name","preview":"preview text","function":{"name":"nested_func"}}""",
+        )
+        assertEquals("legacy_name", nestedWithTopLevel.displayName)
+
+        // 2. Nested function name is used when top-level name is absent/blank
+        val topLevelOnly = HermesJson.decodeFromString<ToolCall>(
+            """{"id":"call_2","preview":"preview text","function":{"name":"nested_func"}}""",
+        )
+        assertEquals("nested_func", topLevelOnly.displayName)
+
+        // 3. Preview takes precedence over id when both name shapes are absent/blank
+        val previewOnly = HermesJson.decodeFromString<ToolCall>(
+            """{"id":"call_3","preview":"Line 1 of preview\nLine 2"}""",
+        )
+        assertEquals("Line 1 of preview", previewOnly.displayName)
+
+        // 4. Preview longer than 48 chars is truncated to 48 chars
+        val longPreview = HermesJson.decodeFromString<ToolCall>(
+            """{"id":"call_4","preview":"This is a very long preview line that exceeds forty-eight characters total"}""",
+        )
+        assertEquals("This is a very long preview line that exceeds fo", longPreview.displayName)
+
+        // 5. id is used when function.name, name, and preview are absent
+        val idOnly = HermesJson.decodeFromString<ToolCall>(
+            """{"id":"call_opaque_id_123"}""",
+        )
+        assertEquals("call_opaque_id_123", idOnly.displayName)
+
+        // 6. Default "Tool" when all are absent or blank
+        val emptyTool = HermesJson.decodeFromString<ToolCall>("""{}""")
+        assertEquals("Tool", emptyTool.displayName)
+    }
+
+    @Test
+    fun parsesFunctionArgumentsWhenTopLevelArgsAbsent() {
+        // Valid JSON string object
+        val stringArgs = HermesJson.decodeFromString<ToolCall>(
+            """{"id":"c1","function":{"name":"f","arguments":"{\"key\":\"value\",\"num\":42,\"flag\":true}"}}""",
+        )
+        assertEquals(JsonPrimitive("value"), stringArgs.args?.get("key"))
+        assertEquals(JsonPrimitive(42), stringArgs.args?.get("num"))
+        assertEquals(JsonPrimitive(true), stringArgs.args?.get("flag"))
+
+        // Direct JSON object (in case server sends object directly)
+        val objectArgs = HermesJson.decodeFromString<ToolCall>(
+            """{"id":"c2","function":{"name":"f","arguments":{"direct":"object"}}}""",
+        )
+        assertEquals(JsonPrimitive("object"), objectArgs.args?.get("direct"))
+
+        // Top-level args take precedence over nested function arguments
+        val bothArgs = HermesJson.decodeFromString<ToolCall>(
+            """{"id":"c3","args":{"source":"top"},"function":{"name":"f","arguments":"{\"source\":\"nested\"}"}}""",
+        )
+        assertEquals(JsonPrimitive("top"), bothArgs.args?.get("source"))
+    }
+
+    @Test
+    fun handlesMalformedAndNonObjectFunctionArgumentsWithoutCrashing() {
+        // Malformed JSON string
+        val malformed = HermesJson.decodeFromString<ToolCall>(
+            """{"id":"call_1","function":{"name":"search","arguments":"{\"query\": unclosed string..."}}""",
+        )
+        assertEquals("search", malformed.displayName)
+        assertEquals("{\"query\": unclosed string...", malformed.function?.arguments)
+        assertNull(malformed.args)
+
+        // Non-object JSON: array
+        val arrayArgs = HermesJson.decodeFromString<ToolCall>(
+            """{"id":"call_2","function":{"name":"search","arguments":"[1, 2, 3]"}}""",
+        )
+        assertEquals("search", arrayArgs.displayName)
+        assertNull(arrayArgs.args)
+
+        // Non-object JSON: primitive string
+        val stringPrimitiveArgs = HermesJson.decodeFromString<ToolCall>(
+            """{"id":"call_3","function":{"name":"search","arguments":"\"plain text string\""}}""",
+        )
+        assertEquals("search", stringPrimitiveArgs.displayName)
+        assertNull(stringPrimitiveArgs.args)
+
+        // Non-object JSON: number
+        val numberArgs = HermesJson.decodeFromString<ToolCall>(
+            """{"id":"call_4","function":{"name":"search","arguments":"12345"}}""",
+        )
+        assertEquals("search", numberArgs.displayName)
+        assertNull(numberArgs.args)
+
+        // Non-object JSON: boolean
+        val boolArgs = HermesJson.decodeFromString<ToolCall>(
+            """{"id":"call_5","function":{"name":"search","arguments":"true"}}""",
+        )
+        assertEquals("search", boolArgs.displayName)
+        assertNull(boolArgs.args)
+
+        // Empty string
+        val emptyArgs = HermesJson.decodeFromString<ToolCall>(
+            """{"id":"call_6","function":{"name":"search","arguments":""}}""",
+        )
+        assertEquals("search", emptyArgs.displayName)
+        assertNull(emptyArgs.args)
+
+        // Whitespace-only string
+        val whitespaceArgs = HermesJson.decodeFromString<ToolCall>(
+            """{"id":"call_7","function":{"name":"search","arguments":"   "}}""",
+        )
+        assertEquals("search", whitespaceArgs.displayName)
+        assertNull(whitespaceArgs.args)
+
+        // Null arguments
+        val nullArgs = HermesJson.decodeFromString<ToolCall>(
+            """{"id":"call_8","function":{"name":"search","arguments":null}}""",
+        )
+        assertEquals("search", nullArgs.displayName)
+        assertNull(nullArgs.args)
+    }
+
+    @Test
+    fun decodesChatMessageWithToolCallsAndRoundTrips() {
+        val json = """
+            {
+              "role": "assistant",
+              "content": "Running the tool now...",
+              "tool_calls": [
+                {
+                  "id": "call_fn_1",
+                  "type": "function",
+                  "function": {
+                    "name": "get_weather",
+                    "arguments": "{\"location\":\"San Francisco\",\"unit\":\"celsius\"}"
+                  },
+                  "extra_future_field": "tolerant"
+                },
+                {
+                  "id": "call_fn_2",
+                  "name": "legacy_tool",
+                  "preview": "Legacy preview",
+                  "args": {"count": 5}
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val message = HermesJson.decodeFromString<ChatMessage>(json)
+
+        assertEquals(2, message.toolCalls?.size)
+
+        val first = message.toolCalls?.get(0)
+        assertEquals("call_fn_1", first?.id)
+        assertEquals("function", first?.type)
+        assertEquals("get_weather", first?.function?.name)
+        assertEquals("get_weather", first?.displayName)
+        assertEquals(JsonPrimitive("San Francisco"), first?.args?.get("location"))
+
+        val second = message.toolCalls?.get(1)
+        assertEquals("call_fn_2", second?.id)
+        assertEquals("legacy_tool", second?.name)
+        assertEquals("legacy_tool", second?.displayName)
+        assertEquals("Legacy preview", second?.preview)
+        assertEquals(JsonPrimitive(5), second?.args?.get("count"))
+
+        // Roundtrip serialization
+        val encoded = HermesJson.encodeToString(message)
+        val decodedRoundtrip = HermesJson.decodeFromString<ChatMessage>(encoded)
+
+        assertEquals("get_weather", decodedRoundtrip.toolCalls?.get(0)?.displayName)
+        assertEquals(JsonPrimitive("San Francisco"), decodedRoundtrip.toolCalls?.get(0)?.args?.get("location"))
+        assertEquals("legacy_tool", decodedRoundtrip.toolCalls?.get(1)?.displayName)
+    }
+
+    @Test
+    fun persistedToolCallConvertsToToolCallWithDisplayName() {
+        val persisted = PersistedToolCall(
+            name = "read_file",
+            snippet = "fun main() {}",
+            tid = "tid-123",
+            assistantMsgIdx = 4,
+            args = mapOf("path" to JsonPrimitive("main.kt")),
+        )
+
+        val toolCall = persisted.toToolCall(0)
+
+        assertEquals("tid-123", toolCall.id)
+        assertEquals("read_file", toolCall.name)
+        assertEquals("fun main() {}", toolCall.preview)
+        assertEquals("read_file", toolCall.displayName)
+        assertEquals(JsonPrimitive("main.kt"), toolCall.args?.get("path"))
+    }
+
+    @Test
+    fun turnFileChangeAggregatorRecognizesNestedFunctionShape() {
+        val toolCall = HermesJson.decodeFromString<ToolCall>(
+            """
+            {
+              "id": "call_edit",
+              "type": "function",
+              "function": {
+                "name": "edit_file",
+                "arguments": "{\"path\":\"src/Main.kt\"}"
+              }
+            }
+            """.trimIndent(),
+        )
+
+        val summary = TurnFileChangeAggregator.summarize(
+            toolCalls = listOf(toolCall),
+            statusFiles = listOf(
+                GitFileChange(path = "src/Main.kt", status = "modified", additions = 5, deletions = 2),
+            ),
+        )
+
+        assertEquals(1, summary.fileCount)
+        assertEquals("src/Main.kt", summary.changes.single().path)
+        assertEquals(5, summary.totalAdditions)
+        assertEquals(2, summary.totalDeletions)
+        assertEquals(TurnFileAction.Edited, summary.changes.single().action)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes Android tool-call cards displaying opaque provider call IDs such as `call_...` instead of the actual tool name.

The Hermes WebUI already supports the standard OpenAI-compatible shape:

```json
{
  "id": "call_...",
  "type": "function",
  "function": {
    "name": "read_file",
    "arguments": "{\"path\":\"README.md\"}"
  }
}
```

The Android port previously decoded only the top-level internal `name` field and fell back to `id` when it was absent.

## Changes

- Decode `tool_calls[].function.name` and `function.arguments`.
- Parse object arguments supplied as JSON strings or direct JSON objects.
- Preserve legacy Hermes fields: top-level `name`, `args`, `preview`, `result`, and `is_error`.
- Keep malformed and non-object arguments tolerant without crashing.
- Use nested function names in file-change aggregation as well.
- Add regression tests for standard calls, legacy calls, fallback precedence, malformed arguments, chat-message round trips, persisted calls, and file-change summaries.
- Bump Android version to `1.1.3` / version code `33` for the release artifact.

## Verification

- `ANDROID_HOME=/opt/android-sdk ./gradlew testDebugUnitTest lintRelease assembleRelease bundleRelease`
- Unit tests passed.
- Release lint passed.
- Release APK and AAB built successfully.
- Release APK signature verified with APK Signature Scheme v2.

The implementation commit also produced the tested fork release:
https://github.com/boudywho/hermex-android-port/releases/tag/android-v1.1.3
